### PR TITLE
bin/pm2 shows undefined instead of a program name

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -192,16 +192,14 @@ commander.command('kill')
 commander.command('*')
          .action(function() {
   console.log(PREFIX_MSG + '\nCommand not found');
-  commander.outputHelp();
-  process.exit(ERROR_EXIT);
+  badArguments();
 });
 
 //
 // Display help
 //
 if (process.argv.length == 2) {
-  commander.outputHelp();
-  process.exit(ERROR_EXIT);
+  badArguments();
 }
 
 //
@@ -558,6 +556,11 @@ function speedList() {
     UX.dispAsTable(list);
     process.exit(SUCCESS_EXIT);
   });
+}
+
+function badArguments() {
+  commander.parse(process.argv).outputHelp();
+  process.exit(ERROR_EXIT);
 }
 
 //


### PR DESCRIPTION
A program needs to call `commander.parse()` before `commander.outputHelp()`, otherwise commander module doesn't know a name of the executable file and shows "undefined" instead:

```
alex@elu:/tmp/node_modules/pm2/bin$ ./pm2 | head

  Usage: undefined [cmd] app
```
