### PR TITLE
color issues

### DIFF
--- a/lib/Log.js
+++ b/lib/Log.js
@@ -4,13 +4,13 @@
 var fs = require('fs');
 
 var colors = [
-  '\x1B[34m',
-  '\x1B[36m',
-  '\x1B[32m',
-  '\x1B[35m',
-  '\x1B[31m',
-  '\x1B[90m',
-  '\x1B[33m',
+  '\x1B[34m', // blue
+  '\x1B[36m', // cyan
+  '\x1B[32m', // green
+  '\x1B[35m', // magenta
+  '\x1B[31m', // red
+  '\x1B[90m', // grey
+  '\x1B[33m', // yellow
 ];
 
 var gl_idx = 0;


### PR DESCRIPTION
1. If you spawn more than 20 processes, the color would be undefined and logs will look like that:

```
undefined[sinopia out (l0)] //localhost:4873/
undefined[sinopia out (l1)] Server is listening on http://localhost:4873/
undefined[sinopia out (l2)] Server is listening on http://localhost:4873/
```

... and repeating the same colors multiple times just smells bad...
1. Removed black color. I use _konsole_ terminal with black background. It's the default, and I believe a lot of people do so. But black text on a black background isn't very readable to say the least.

If you want to use black, please set a light background explicitly.

There might be a way to get around it by querying a terminal background and avoiding similar colors. But it sounds way too complex for the task.
1. I commented out each color to improve readability of a code. 
