### PR TITLE
output human-readable memory info in `pm2 list`

### DIFF
--- a/lib/CliUx.js
+++ b/lib/CliUx.js
@@ -16,7 +16,7 @@ UX.dispAsTable = function(list) {
       l.pid,
       l.status,
       l.opts.restart_time ? l.opts.restart_time : 0,
-      l.monit ? l.monit.memory : '',
+      l.monit ? UX.bytesToSize(l.monit.memory, 3) : '',
       l.opts.fileError,
     ];
 
@@ -59,3 +59,25 @@ UX.processing = {
     clearInterval(timer);
   }
 };
+
+UX.bytesToSize = function(bytes, precision) {
+  var kilobyte = 1024;
+  var megabyte = kilobyte * 1024;
+  var gigabyte = megabyte * 1024;
+  var terabyte = gigabyte * 1024;
+
+  if ((bytes >= 0) && (bytes < kilobyte)) {
+    return bytes + ' B';
+  } else if ((bytes >= kilobyte) && (bytes < megabyte)) {
+    return (bytes / kilobyte).toFixed(precision) + ' KB';
+  } else if ((bytes >= megabyte) && (bytes < gigabyte)) {
+    return (bytes / megabyte).toFixed(precision) + ' MB';
+  } else if ((bytes >= gigabyte) && (bytes < terabyte)) {
+    return (bytes / gigabyte).toFixed(precision) + ' GB';
+  } else if (bytes >= terabyte) {
+    return (bytes / terabyte).toFixed(precision) + ' TB';
+  } else {
+    return bytes + ' B';
+  }
+};
+

--- a/lib/Monit.js
+++ b/lib/Monit.js
@@ -4,6 +4,7 @@
 
 var multimeter = require('multimeter');
 var os         = require('os');
+var CliUx      = require('./CliUx');
 var bars       = {};
 
 // Cst for light programs
@@ -86,7 +87,7 @@ Monit.drawRatio = function(bar_memory, memory) {
   
   bar_memory.ratio(memory,
 		   scale,
-		   bytesToSize(memory, 3));   
+		   CliUx.bytesToSize(memory, 3));   
 };
 
 Monit.refresh = function(dt) {
@@ -100,23 +101,3 @@ Monit.refresh = function(dt) {
   });
 };
 
-function bytesToSize(bytes, precision) {
-  var kilobyte = 1024;
-  var megabyte = kilobyte * 1024;
-  var gigabyte = megabyte * 1024;
-  var terabyte = gigabyte * 1024;
-
-  if ((bytes >= 0) && (bytes < kilobyte)) {
-    return bytes + ' B';
-  } else if ((bytes >= kilobyte) && (bytes < megabyte)) {
-    return (bytes / kilobyte).toFixed(precision) + ' KB';
-  } else if ((bytes >= megabyte) && (bytes < gigabyte)) {
-    return (bytes / megabyte).toFixed(precision) + ' MB';
-  } else if ((bytes >= gigabyte) && (bytes < terabyte)) {
-    return (bytes / gigabyte).toFixed(precision) + ' GB';
-  } else if (bytes >= terabyte) {
-    return (bytes / terabyte).toFixed(precision) + ' TB';
-  } else {
-    return bytes + ' B';
-  }
-}


### PR DESCRIPTION
It's probably a good idea to display memory info like this "22.977 MB" instead of "22977672" in pm2 list.

I also moved function "bytesToSize" to CliUx because I used it in both places, and logically it's more suited to be in CliUx... not sure though

PS: lowercase "b" looks nicer imho :)
