### PR TITLE
display issues in konsole terminal

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -11,7 +11,7 @@ var cst = require('../constants.js');
 var util = require('util');
 var watch = require('watch');
 
-const PREFIX_MSG        = '\x1B[32m⌬ PM2\x1B[39m ';
+const PREFIX_MSG        = '\x1B[32m⌬ PM2 \x1B[39m';
 const SUCCESS_EXIT      = 0;
 const ERROR_EXIT        = 1;
 const SAMPLE_FILE_PATH  = '../lib/sample.json';


### PR DESCRIPTION
There's this well-known bug: https://bugs.kde.org/show_bug.cgi?id=297390

![konsole](http://kocharin.ru/pm2_konsole.png)

So, I suggest as a workaround to make a last space use green foreground. If the last character of the colored line is a space, then this space would be cut off, not a letter, and a prompt will look as it should.
