### PR TITLE
please use either tabs or spaces, but not both

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -513,10 +513,10 @@ CLI.monit = function() {
 
     function refresh(cb) {
       Satan.executeRemote('list', {}, function(err, list) {
-	setTimeout(function() {
-	  Monit.refresh(list);
-	  refresh();
-	}, 400);
+        setTimeout(function() {
+          Monit.refresh(list);
+          refresh();
+        }, 400);
       });
     }
     refresh();

--- a/lib/God.js
+++ b/lib/God.js
@@ -22,16 +22,16 @@ var God = module.exports = {
 (function initEngine() {
   cluster.on('online', function(clu) {
     console.log("%s - id%d worker online",
-		clu.opts.pm_exec_path,
-		clu.pm_id);
+                clu.opts.pm_exec_path,
+                clu.pm_id);
     God.clusters_db[clu.pm_id].status = 'online';
   });
 
   cluster.on('exit', function(clu, code, signal) {
     console.log('Script %s %d exited code %d',
-		clu.opts.pm_exec_path,
-		clu.pm_id,
-		code);
+                clu.opts.pm_exec_path,
+                clu.pm_id,
+                code);
 
     God.clusters_db[clu.pm_id].status = 'starting';
 
@@ -41,9 +41,9 @@ var God = module.exports = {
 
     if (clu.opts.max !== undefined) {
       if (clu.opts.max <= 0) {
-	God.clusters_db[clu.pm_id].status = 'stopped';
+        God.clusters_db[clu.pm_id].status = 'stopped';
         delete God.clusters_db[clu.pm_id];
-	return ;
+        return ;
       }
       else clu.opts.max -= 1;
     }
@@ -68,8 +68,8 @@ God.stopAll = function(cb) {
     if (i <= -1) return cb(null, God.getFormatedProcesses());
     if (processes[i].state == 'stopped') return ex(processes, i - 1);
     return God.stopProcess(processes[i], function() {
-	     ex(processes, i - 1);
-	   });
+             ex(processes, i - 1);
+           });
   })(pros, l - 1);
 };
 
@@ -104,10 +104,10 @@ God.getFormatedProcesses = function() {
   for (var key in db) {
     if (db[key])
       arr.push({
-	pid : db[key].process.pid,
-	opts : db[key].opts,
-	pm_id : db[key].pm_id,
-	status : db[key].status
+        pid : db[key].process.pid,
+        opts : db[key].opts,
+        pm_id : db[key].pm_id,
+        status : db[key].status
       });
   }
   return arr;
@@ -189,13 +189,13 @@ God.prepare = function(opts, cb) {
     var arr = [];
     (function ex(i) {
       if (i <= 0) {
-	if (cb != null) return cb(null, arr);
-	return true;
+        if (cb != null) return cb(null, arr);
+        return true;
       }
       return execute(JSON.parse(JSON.stringify(opts)), function(err, clu) { // deep copy
-	       arr.push(clu);
-	       ex(i - 1);
-	     });
+               arr.push(clu);
+               ex(i - 1);
+             });
     })(opts.instances);
   }
   else return execute(opts, cb);

--- a/lib/Log.js
+++ b/lib/Log.js
@@ -65,13 +65,13 @@ Log.stream = function(path, title) {
       if (currSize > prevSize) return true;
 
       var rstream = fs.createReadStream(path, {
-	encoding : 'utf8',
-	start : currSize,
-	end : prevSize
+        encoding : 'utf8',
+        start : currSize,
+        end : prevSize
       });
 
       rstream.on('data', function(data) {
-	print_data(odb, title, data);
+        print_data(odb, title, data);
       });
 
       currSize = stat.size;
@@ -90,8 +90,8 @@ function print_data(odb, title, data) {
   lines.forEach(function(l) {
     if (l)
       console.log(odb.color + '[%s (l%d)]\x1B[39m %s',
-		  title,
-		  odb.l++,
-		  l);
+                  title,
+                  odb.l++,
+                  l);
   });
 };

--- a/lib/Monit.js
+++ b/lib/Monit.js
@@ -85,8 +85,8 @@ Monit.drawRatio = function(bar_memory, memory) {
   else scale = RATIO_T4;
   
   bar_memory.ratio(memory,
-		   scale,
-		   bytesToSize(memory, 3));   
+                   scale,
+                   bytesToSize(memory, 3));   
 };
 
 Monit.refresh = function(dt) {

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -24,9 +24,9 @@ Satan.onReady = function() {
     }
     else {
       Satan.pingDaemon(function(ab) {
-	if (ab == false)
-	  return Satan.launchDaemon(Satan.launchRPC);
-	return Satan.launchRPC();
+        if (ab == false)
+          return Satan.launchDaemon(Satan.launchRPC);
+        return Satan.launchRPC();
       });
     }
   })();
@@ -45,16 +45,16 @@ Satan.remoteWrapper = function() {
     var stdout = fs.createWriteStream(cst.PM2_LOG_FILE_PATH, { flags : 'a' });
 
     process.stderr.write = (function(write) {
-	                      return function(string, encoding, fd) {
-	                        stdout.write(JSON.stringify([(new Date()).toISOString(), string]));
-	                      };
+                              return function(string, encoding, fd) {
+                                stdout.write(JSON.stringify([(new Date()).toISOString(), string]));
+                              };
                             }
                            )(process.stderr.write);
 
     process.stdout.write = (function(write) {
-	                      return function(string, encoding, fd) {
+                              return function(string, encoding, fd) {
                                 stdout.write(JSON.stringify([(new Date()).toISOString(), string]));
-	                      };
+                              };
                             })(process.stdout.write);
   }
 
@@ -73,7 +73,7 @@ Satan.remoteWrapper = function() {
   server.expose({
     prepare : function(opts, fn) {
       God.prepare(opts, function(err, clu) {
-	fn(null, stringifyOnce(clu, undefined, 0));
+        fn(null, stringifyOnce(clu, undefined, 0));
       });
     },
     list : function(opts, fn) {
@@ -193,7 +193,7 @@ function stringifyOnce(obj, replacer, indent){
     var printedObjIndex = false;
     printedObjects.forEach(function(obj, index){
       if(obj===value){
-	printedObjIndex = index;
+        printedObjIndex = index;
       }
     });
 
@@ -204,9 +204,9 @@ function stringifyOnce(obj, replacer, indent){
       printedObjects.push(value);
       printedObjectKeys.push(qualifiedKey);
       if(replacer){
-	return replacer(key, value);
+        return replacer(key, value);
       }else{
-	return value;
+        return value;
       }
     }
   }


### PR DESCRIPTION
Everybody has a different tab width. Most common is 4 spaces, but I personally use 3. Github uses 2 to display a diff.

I do not usually argue about codestyle, but code that looks like this sure can be considered a bug:

``` javascript
    var bar_cpu = Monit.multi(40, (i * 2) + 3 + i, {
      width: 30,
      solid: {
    text: '|',
    foreground: 'white',
    background: 'blue'
      },
      empty: {
    text: ' '
      }
    });
```
