### PR TITLE
bug with outputHelp

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -192,14 +192,17 @@ commander.command('kill')
 commander.command('*')
          .action(function() {
   console.log(PREFIX_MSG + '\nCommand not found');
-  badArguments();
+  commander.outputHelp();
+  process.exit(ERROR_EXIT);
 });
 
 //
 // Display help
 //
 if (process.argv.length == 2) {
-  badArguments();
+  commander.parse(process.argv);
+  commander.outputHelp();
+  process.exit(ERROR_EXIT);
 }
 
 //
@@ -556,11 +559,6 @@ function speedList() {
     UX.dispAsTable(list);
     process.exit(SUCCESS_EXIT);
   });
-}
-
-function badArguments() {
-  commander.parse(process.argv).outputHelp();
-  process.exit(ERROR_EXIT);
 }
 
 //


### PR DESCRIPTION
I was a bit too quick with pull request #8, and introduced a bug there.

process.argv needs to be parsed here:
https://github.com/Unitech/pm2/blob/master/bin/pm2#L201

but NOT here:
https://github.com/Unitech/pm2/blob/master/bin/pm2#L195

So now `pm2 blablabla` goes to infinite recursion. I hope this time I get this right. :)
