### PR TITLE
set process.title to meaningful value

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -19,6 +19,9 @@ var cst = require('../constants');
 
   fs.writeFileSync(pidFile, process.pid);
 
+  if (process.env.name != null)
+    process.title = 'pm2: ' + process.env.name;
+
   exec(script, outFile, errFile);
 })();
 


### PR DESCRIPTION
This patch sets a process title to "pm2: <name>".

I'm getting tired of seeing something like this in the process list :)

```
17837 alex      20   0  932m  89m 8788 S  0.0  4.8   0:18.20 node                                   
17829 alex      20   0  932m  89m 8788 S  0.0  4.8   0:18.43 node                                   
17843 alex      20   0  931m  88m 8788 S  0.0  4.7   0:18.08 node                                   
17831 alex      20   0  995m  87m 8788 S  0.0  4.7   0:18.29 node                                   
17959 alex      20   0  836m  69m 8676 S  0.0  3.7   0:17.11 node                                   
17889 alex      20   0  756m  34m 8536 S  0.0  1.9   0:00.75 node                                   
17895 alex      20   0  756m  34m 8540 S  0.0  1.9   0:00.76 node                                   
17901 alex      20   0  756m  34m 8540 S  0.0  1.9   0:00.74 node                                   
17887 alex      20   0  756m  34m 8540 S  0.0  1.9   0:00.73 node                                   
17801 alex      20   0  748m  29m 8456 S  0.0  1.6   0:00.58 node                                   
17807 alex      20   0  748m  29m 8456 S  0.0  1.6   0:00.59 node                                   
17813 alex      20   0  748m  29m 8456 S  0.0  1.6   0:00.59 node                                   
17799 alex      20   0  748m  29m 8456 S  0.0  1.6   0:00.59 node                                   
17923 alex      20   0 1004m  26m 8516 S  0.0  1.4   0:00.78 node                                   
17757 alex      20   0  811m  21m 7960 S  0.0  1.2   0:00.79 node                                   
17984 alex      20   0  742m  19m 8232 S  0.0  1.1   0:00.78 node                                   
```
