### PR TITLE
use version information from package.json file

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -8,6 +8,7 @@ var Satan = require('../lib/Satan');
 var fs = require('fs');
 var path = p = require('path');
 var cst = require('../constants.js');
+var pkg = require('../package.json');
 var util = require('util');
 var watch = require('watch');
 
@@ -19,7 +20,7 @@ const STARTUP_SCRIPT    = '../lib/scripts/pm2-init.sh';
 
 //console.log();
 
-commander.version(cst.VERSION)
+commander.version(pkg.version)
          .option('-v --verbose', 'Display all data')
          .option('-f --force', 'Force actions')
          .option('-i --instances <number>', 'Lunch [number] instances (clustered with same socket)', parseInt)

--- a/constants.js
+++ b/constants.js
@@ -8,7 +8,6 @@ var p = require('path');
 DEFAULT_FILE_PATH = p.resolve(process.env.HOME, '.pm2');
 
 module.exports = {
-  VERSION           : '1.0.3',
   DEFAULT_FILE_PATH : DEFAULT_FILE_PATH,
   PM2_LOG_FILE_PATH : p.join(p.resolve(process.env.HOME, '.pm2'), 'pm2.log'),
   DEFAULT_PID_PATH  : p.join(DEFAULT_FILE_PATH, 'pids'),


### PR DESCRIPTION
There are two version strings in pm2 right now: version of npm package is 0.4.3, and "pm -V" prints out 1.0.3.

I suppose it's unintentional, so I suggest to use version from package.json everywhere.

So we can require package.json and get version information from there. I got this idea from "express" source code:
https://github.com/visionmedia/express/blob/master/bin/express#L10

Too bad that commander module can't just do it automatically. :(
