### PR TITLE
jlist command does not output valid JSON

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -554,7 +554,7 @@ CLI.list = function() {
 CLI.jlist = function() {
   Satan.executeRemote('list', {}, function(err, list) {
     if (err) process.exit(ERROR_EXIT);
-    console.log(list);
+    console.log(JSON.stringify(list));
     process.exit(SUCCESS_EXIT);
   });
 };


### PR DESCRIPTION
``` bash
$ pm2 jlist | jsonlint

[Error: Parse error on line 1:
[ { pid: 12422,    opts
----^
Expecting 'STRING', '}', got 'undefined']
```

The `list` object needs to be run through `JSON.stringify()` before it is logged to the console.
