### PR TITLE
Add config options for conditionally stopping processes

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -24,7 +24,7 @@ var God = module.exports = {
     console.log("%s - id%d worker online",
                 clu.opts.pm_exec_path,
                 clu.pm_id);
-    God.clusters_db[clu.pm_id].status = 'online';
+    clu.status = 'online';
   });
 
   cluster.on('exit', function(clu, code, signal) {
@@ -34,11 +34,22 @@ var God = module.exports = {
                 code);
 
     // Keep track of the number of restarts
-    God.clusters_db[clu.pm_id].opts.restart_time = God.clusters_db[clu.pm_id].opts.restart_time + 1;
+    clu.opts.restart_time = clu.opts.restart_time + 1;
 
-    var stopped = God.clusters_db[clu.pm_id].process.pid == -1 ? true : false;
+    var stopped = clu.process.pid == -1 ? true : false;
+    var overlimit = false;
+    var uptime = Date.now() - clu.opts.pm_uptime;
+    if (!clu.opts.min_uptime || uptime <= clu.opts.min_uptime) {
+      clu.opts.unstable_restarts += 1;
+    }
+    if (clu.opts.max_restarts && clu.opts.unstable_restarts >= clu.opts.max_restarts) {
+      overlimit = true;
+      console.log('Script %s had too many unstable restarts (%d) and has been stopped.',
+                  clu.opts.pm_exec_path,
+                  clu.opts.unstable_restarts);
+    }
     delete God.clusters_db[clu.pm_id];
-    if (!stopped) execute(clu.opts);
+    if (!stopped && !overlimit) execute(clu.opts);
   });
 })();
 
@@ -231,6 +242,12 @@ function execute(env, cb) {
   // First time the script is exec
   if (env['restart_time'] === undefined) {
     env['restart_time'] = 0;
+  }
+
+  // Keep track of unstable restarts
+  // i.e. restarts that are too fast
+  if (env['unstable_restarts'] === undefined) {
+    env['unstable_restarts'] = 0;
   }
 
   var clu = cluster.fork(env);


### PR DESCRIPTION
- "min_uptime":
  if a process is restarted with an uptime smaller than this value,
  this restart counts as an unstable restart. If this option is not specified,
  all restarts are considered unstable.
- "max_restarts":
  if the number of unstable restarts exceeds this number,
  the process will be stopped and a message with number with restarts will be logged.
