### PR TITLE
make logs line break properly

### DIFF
--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -80,18 +80,13 @@ Satan.remoteWrapper = function() {
     //
     var stdout = fs.createWriteStream(cst.PM2_LOG_FILE_PATH, { flags : 'a' });
 
-    process.stderr.write = (function(write) {
-                              return function(string, encoding, fd) {
-                                stdout.write(JSON.stringify([(new Date()).toISOString(), string]));
-                              };
-                            }
-                           )(process.stderr.write);
+    process.stderr.write = function(string) {
+      stdout.write(new Date().toISOString() + ' : ' + string);
+    }
 
-    process.stdout.write = (function(write) {
-                              return function(string, encoding, fd) {
-                                stdout.write(JSON.stringify([(new Date()).toISOString(), string]));
-                              };
-                            })(process.stdout.write);
+    process.stdout.write = function(string) {
+      stdout.write(new Date().toISOString() + ' : ' + string);
+    }
   }
 
   // Only require here because God init himself


### PR DESCRIPTION
I'm not sure why the current output uses `JSON.stringify`, but the result for me is that `pm2.log` has no line break at all and is not humanly readable, so I changed it to a simple string concatenation.
