### PR TITLE
gracefully reload process

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -135,6 +135,16 @@ commander.command('restart <pm2_id|all>')
   });
 
 //
+// Reload process(es)
+//
+commander.command('reload <pm2_id|all>')
+  .description('reload all processes or a specific process pm2 id')
+  .action(function(pm2_id) {
+    UX.processing.start();
+    CLI.reload(pm2_id);
+  });
+
+//
 // Stop All processes
 //
 commander.command('restartAll')
@@ -497,6 +507,20 @@ CLI.web = function() {
     console.log(PREFIX_MSG + 'Process launched');
     speedList();
   });
+};
+
+
+CLI.reload = function (cluster) {
+  Satan.executeRemote('reload', cluster, function(err) {
+    if (err) {
+      console.error('Cannot reload process: ' + err);
+      process.exit(ERROR_EXIT);
+      return;
+    }
+    console.log('\n' + PREFIX_MSG + 'All processes reloaded');
+    process.exit(SUCCESS_EXIT);
+  });
+
 };
 
 CLI.restart = function(pm2_id) {

--- a/lib/God.js
+++ b/lib/God.js
@@ -66,6 +66,32 @@ God.stopAll = function(cb) {
   })(pros, l - 1);
 };
 
+God.reload = function reload(opts, cb) {
+  var workerAmount = 0;
+  for (var id in God.clusters_db) {
+    workerAmount++;
+    (function (oldWorker, currentWorkerIndex) {
+      var newWorker = execute(oldWorker.opts);
+      newWorker.once('listening', function(){
+        console.log("%s - id%d worker listening",
+          newWorker.opts.pm_exec_path,
+          newWorker.pm_id);
+        oldWorker.once('disconnect', function(){
+          console.log('%s - id%d worker disconnect',
+            oldWorker.opts.pm_exec_path,
+            oldWorker.pm_id);
+          God.stopProcess(oldWorker, function(){
+            if(currentWorkerIndex === workerAmount){
+              cb()
+            }
+          });
+        });
+        oldWorker.disconnect();
+      })
+    })(God.clusters_db[id], workerAmount);
+  }
+};
+
 God.getProcesses = function() {
   return God.clusters_db;
 };

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -129,6 +129,11 @@ Satan.remoteWrapper = function() {
     stopAll : function(opts, fn) {
       God.stopAll(fn);
     },
+    reload : function(opts, fn) {
+      God.reload(opts, function(err, data) {
+        fn(err, data);
+      });
+    },
     killMe : function(fn) {
       console.log('Killing daemon');
       fn(null, {});


### PR DESCRIPTION
# What is the problem

My processes are online and listening. I am going to deploy new code. I have to suffer 1-10 seconds server downtime during the restart (even with dump-kill-resurrect). I want to have zero downtime deployment.
# How is the problem solved

When `reload` signal receive, newWorkers are `fork()` ed and made `listening()`. When a newWorker is `listening`, corresponding oldWorker `disconnect()`s http://nodejs.org/api/cluster.html#cluster_worker_disconnect , i.e. the oldWorker will no longer accept new connections, but they (new connections) will be handled by newWorker(s). Existing connection will be allowed to exit as usual.
# What is still wrong

Only 'reload all' at this moment, please give feedback and discuss.
