### PR TITLE
Allow a different bind address through environment

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -13,7 +13,7 @@ module.exports = {
   DEFAULT_PID_PATH  : p.join(DEFAULT_FILE_PATH, 'pids'),
   DEFAULT_LOG_PATH  : p.join(DEFAULT_FILE_PATH, 'logs'),
   DUMP_FILE_PATH    : p.join(DEFAULT_FILE_PATH, 'dump.pm2'),
-  DAEMON_BIND_ADDR  : 'localhost:6666',
+  DAEMON_BIND_ADDR  : process.env.PM2_BIND_ADDR || 'localhost:6666',
   DEBUG             : false,
   WEB_INTERFACE     : 9615,
   MODIFY_REQUIRE    : false

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -152,7 +152,7 @@ Satan.remoteWrapper = function() {
 Satan.launchRPC = function() {
   debug('Launching RPC client');
   Satan.client = new rpc.Client(req);
-  Satan.ev = req.connect(bind.PORT);
+  Satan.ev = req.connect(bind.PORT, bind.HOST);
   Satan.ev.on('connect', function() {
     process.emit('satan:client:ready');
   });
@@ -190,7 +190,8 @@ Satan.launchDaemon = function(cb) {
     env : {
       "DAEMON" : true,
       "SILENT" : cst.DEBUG ? !cst.DEBUG : true,
-      "HOME" : process.env.HOME
+      "HOME" : process.env.HOME,
+      "PM2_BIND_ADDR" : process.env.PM2_BIND_ADDR
     },
     stdio: "ignore"
   }, function(err, stdout, stderr) {
@@ -222,7 +223,7 @@ Satan.pingDaemon = function(cb) {
     debug('Daemon alive');
     cb(true);
   });
-  req.connect(bind.PORT);
+  req.connect(bind.PORT, bind.HOST);
 };
 
 // Change Circular dependies to null


### PR DESCRIPTION
Hi,

I am running on a very restricted environment where I'm not allowed to bind freely (not even on localhost), so I thought controlling the satan bind address would be nice through an environment variable. Hope that's fine with you !
