### PR TITLE
Add the possibility to send a signal to the processes by name or by ID.

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -60,18 +60,18 @@ commander.command('stopAll')
 //
 commander.command('stop <pm2_id|name|all>')
   .description('stop specific process pm2 id or script name (set with --name or script name)')
-  .action(function(pm2_id) {    
+  .action(function(pm2_id) {
     UX.processing.start();
-    
+
     if (pm2_id == 'all') {
       CLI.stopAll();
     }
     else if (isNaN(parseInt(pm2_id))) {
       console.log(PREFIX_MSG + 'Stopping process by name ' + pm2_id);
-      CLI.stopProcessName(pm2_id);
+      CLI.sendSignalToProcessName(pm2_id);
     } else {
       console.log(PREFIX_MSG + 'Stopping process by id ' + pm2_id);
-      CLI.stopId(pm2_id);
+      CLI.sendSignalToProcessId(pm2_id);
     }
   });
 
@@ -141,6 +141,18 @@ commander.command('reload <pm2_id|all>')
   .action(function(pm2_id) {
     UX.processing.start();
     CLI.reload(pm2_id);
+  });
+
+commander.command('sendSignal <signal> <pm2_id|name>')
+  .description('send a signal to a specific process')
+  .action(function(signal, pm2_id) {
+    UX.processing.start();
+    if (isNaN(parseInt(pm2_id))) {
+      CLI.sendSignalToProcessName(pm2_id, signal);
+    }
+    else {
+      CLI.sendSignalToProcessId(pm2_id, signal);
+    }
   });
 
 //
@@ -321,7 +333,7 @@ CLI.startFile = function(script) {
   if (commander.name)
     appConf['name']        = commander.name;
   if (commander.instances)
-    appConf['instances']   = commander.instances;    
+    appConf['instances']   = commander.instances;
   if (commander.error)
     appConf['fileError']   = commander.error;
   if (commander.output)
@@ -330,13 +342,13 @@ CLI.startFile = function(script) {
     appConf['pidFile']     = commander.pid;
   if (commander.cron)
     appConf['cron_restart'] = commander.cron;
-  
+
   // Script arguments
   var opts = commander.rawArgs.indexOf('--') + 1;
   if (opts > 1)
     appConf['args'] = JSON.stringify(commander.rawArgs.slice(opts,
                                                              commander.rawArgs.length));
-  
+
   if (commander.write) {
     var dst_path = path.join(process.env.PWD, path.basename(script, '.js') + '-pm2.json');
     console.log(PREFIX_MSG + 'Writing configuration to ', dst_path);
@@ -597,9 +609,29 @@ CLI.stopAll = function() {
   });
 };
 
-CLI.stopProcessName = function(name) {
-  Satan.executeRemote('stopProcessName', {
-    name : name
+CLI.sendSignalToProcessId = function(pm2_id, signal) {
+  Satan.executeRemote('sendSignalToProcessId', {
+    id : pm2_id,
+    signal : signal
+  }, function(err, list) {
+    if (err) {
+      console.log('\n' + PREFIX_MSG_ERR + pm2_id + ' : pm2 id not found');
+      process.exit(ERROR_EXIT);
+    }
+    console.log('\n');
+    UX.dispAsTable(list);
+    if (signal === undefined) {
+      console.log(PREFIX_MSG + 'Process stopped');
+    }
+    UX.processing.stop();
+    process.exit(SUCCESS_EXIT);
+  });
+};
+
+CLI.sendSignalToProcessName = function(name, signal) {
+  Satan.executeRemote('sendSignalToProcessName', {
+    name : name,
+    signal : signal
   }, function(err, list) {
     if (err) {
       console.error(err);
@@ -610,23 +642,7 @@ CLI.stopProcessName = function(name) {
     UX.processing.stop();
     process.exit(SUCCESS_EXIT);
   });
-};
-
-CLI.stopId = function(pm2_id) {
-  Satan.executeRemote('stopId', {
-    id : pm2_id
-  }, function(err, list) {
-    if (err) {
-      console.log('\n' + PREFIX_MSG_ERR + pm2_id + ' : pm2 id not found');
-      process.exit(ERROR_EXIT);
-    }
-    console.log('\n');
-    //UX.dispAsTable(list);
-    console.log(PREFIX_MSG + 'Process stopped');
-    UX.processing.stop();
-    process.exit(SUCCESS_EXIT);
-  });
-};
+}
 
 CLI.generateSample = function(name) {
   var sample = fs.readFileSync(path.join(__dirname, SAMPLE_FILE_PATH));
@@ -698,7 +714,7 @@ CLI.monit = function() {
       console.log(PREFIX_MSG + 'No online process to monitor');
       process.exit(ERROR_EXIT);
     }
-    
+
     Monit.init(list);
 
     function refresh(cb) {
@@ -719,7 +735,7 @@ CLI.monit = function() {
 
 CLI.streamLogs = function(id) {
   var tdb = {};
-    
+
   Satan.executeRemote('list', {}, function(err, list) {
     if (err) {
       console.error('Error retrieving process list: ' + err);
@@ -774,7 +790,7 @@ function validate(appConf) {
   var instances = appConf['instances'];
   var script    = appConf['script'];
   var cron_pattern = appConf['cron_restart'];
-  
+
   if (instances && isNaN(parseInt(instances)) && instances != 'max') {
     console.log(PREFIX_MSG_ERR + 'Instance option must be an integer or the "max" string');
     process.exit(ERROR_EXIT);
@@ -800,7 +816,7 @@ function validate(appConf) {
 function resolvePaths(app) {
 
   validate(app);
-  
+
   app["pm_exec_path"]    = path.resolve(process.cwd(), app.script);
 
   console.log(app);

--- a/lib/God.js
+++ b/lib/God.js
@@ -103,7 +103,7 @@ God.getMonitorData = function(cb) {
   function ex(i) {
     if (i <= -1) return cb(null, arr);
     var pro = processes[i];
-    
+
     usage.lookup(pro.pid, { keepHistory : true }, function(err, res) {
       if (err) return cb(err);
 
@@ -191,36 +191,46 @@ God.stopProcess = function(clu, cb) {
   setTimeout(cb, 200);
 };
 
-God.stopProcessId = function(id, cb) {
+God.sendSignalToProcessId = function(id, cb, signal) {
   if (!(id in God.clusters_db))
     return cb({msg : 'Process not found'});
-  process.kill(God.clusters_db[id].process.pid);
-  God.clusters_db[id].process.pid = -1;
+  try {
+    console.log('send signal %s to process %s', signal, God.clusters_db[id].process.pid);
+    process.kill(God.clusters_db[id].process.pid, signal);
+  }
+  catch(err) {
+    console.error(err);
+    return cb(err);
+  }
+  //remove the pid when we stop the process
+  if(signal === undefined) {
+    God.clusters_db[id].process.pid = -1;
+  }
   setTimeout(function() {
     cb(null, God.getFormatedProcesses());
   }, 200);
 };
 
 //
-// Stop a process by script name (script path basename)
+// Send a signal to a processes selected by script name (script path basename)
 //
-God.stopProcessName = function(name, cb) {
+God.sendSignalToProcessName = function(name, cb, signal) {
   var arr = Object.keys(God.clusters_db);
-  
+
   (function ex(arr) {
     if (arr[0] == null) return cb(null, God.getFormatedProcesses());
     var key = arr[0];
     if (p.basename(God.clusters_db[key].opts.pm_exec_path) == name ||
         God.clusters_db[key].opts.name == name) {
-      God.stopProcessId(key, function() {
+      God.sendSignalToProcessId(key, function() {
         arr.shift();
         return ex(arr);
-      });
+      }, signal);
     }
     else {
       arr.shift();
       return ex(arr);
-    } 
+    }
   })(arr);
 };
 
@@ -261,7 +271,7 @@ function execute(env, cb) {
   if (env.pm_id && env.opts && env.opts.status == 'stopped') {
     delete God.clusters_db[env.pm_id];
   }
-  
+
   id = God.next_id;
   God.next_id += 1;
 

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -114,16 +114,16 @@ Satan.remoteWrapper = function() {
         fn(err, stringifyOnce(clu, undefined, 0));
       });
     },
-    stopId : function(opts, fn) {
-      God.stopProcessId(opts.id, function(err, clu) {
+    sendSignalToProcessId : function(opts, fn) {
+      God.sendSignalToProcessId(opts.id, function(err, clu) {
         if (err)
           fn(new Error('Process not found'));
         else
           fn(err, clu);
-      });
+      }, opts.signal);
     },
-    stopProcessName : function(opts, fn) {
-      God.stopProcessName(opts.name, fn);
+    sendSignalToProcessName : function (opts, fn) {
+      God.sendSignalToProcessName(opts.name, fn, opts.signal);
     },
     stopAll : function(opts, fn) {
       God.stopAll(fn);

--- a/test/cli.sh
+++ b/test/cli.sh
@@ -224,8 +224,32 @@ OUT=`$pm2 prettylist | grep -o "ECHONEST" | wc -l`
 [ $OUT -eq 0 ] || fail "Process name not stopped"
 success "Processes sucessfully stopped with a specific name"
 
+# Send a process by name
+$pm2 start signal.js -i 2
+# get the log file and the id.
+OUT_LOG=`$pm2 prettylist | grep -m 1 -E "pm_out_log_path:" | sed "s/.*'\([^']*\)',/\1/"`
+cat /dev/null > $OUT_LOG
 
+$pm2 sendSignal SIGUSR2 signal.js
 
+OUT=`grep "SIGUSR2" "$OUT_LOG" | wc -l`
+[ $OUT -eq 2 ] || fail "Signal not received by the process name"
+success "Processes sucessfully receives the signal"
+
+$pm2 stop signal.js
+
+# Send a process by id
+$pm2 start signal.js
+# get the log file and the id.
+OUT_LOG=`$pm2 prettylist | grep -m 1 -E "pm_out_log_path:" | sed "s/.*'\([^']*\)',/\1/"`
+ID=`$pm2 prettylist | grep -E "pm_id:" | sed "s/.*pm_id: \([^,]*\),/\1/"`
+cat /dev/null > $OUT_LOG
+
+$pm2 sendSignal SIGUSR2 $ID
+
+OUT=`grep "SIGUSR2" "$OUT_LOG" | wc -l`
+[ $OUT -eq 1 ] || fail "Signal not received by the process name"
+success "Processes sucessfully receives the signal"
 
 
 $pm2 kill

--- a/test/fixtures/signal.js
+++ b/test/fixtures/signal.js
@@ -1,0 +1,7 @@
+setInterval(function() {
+  console.log('ok');
+}, 30);
+
+process.on('SIGUSR2', function () {
+  console.log('SIGUSR2');
+});

--- a/test/god.mocha.js
+++ b/test/god.mocha.js
@@ -13,11 +13,11 @@ describe('God', function() {
     God.should.have.property('getFormatedProcesses');
     God.should.have.property('checkProcess');
     God.should.have.property('stopAll');
-    God.should.have.property('stopProcessId');
+    God.should.have.property('sendSignalToProcessId');
   });
 
   describe('Special functions for God', function() {
-    it('should kill a process by name', function(done) {
+    it('should send a kill signal to a process selected by name', function(done) {
       God.prepare({
         pm_exec_path    : path.resolve(process.cwd(), 'test/fixtures/echo.js'),
         pm_err_log_path : path.resolve(process.cwd(), 'test/errLog.log'),
@@ -25,14 +25,14 @@ describe('God', function() {
         pm_pid_path     : path.resolve(process.cwd(), 'test/child'),
         instances       : 2
       }, function(err, procs) {
-	God.getFormatedProcesses().length.should.equal(2);
+        God.getFormatedProcesses().length.should.equal(2);
 
-        God.stopProcessName('echo.js', function() {
+        God.sendSignalToProcessName('echo.js', function() {
           God.getFormatedProcesses().length.should.equal(0);
           God.stopAll(done);
         });
       });
-    }); 
+    });
   });
 
   describe('One process', function() {
@@ -41,7 +41,7 @@ describe('God', function() {
     before(function(done) {
       God.stopAll(done);
     });
-    
+
     after(function(done) {
       God.stopAll(done);
     });
@@ -97,7 +97,7 @@ describe('God', function() {
       });
     });
 
-    it('should start maximum processes depending on CPU numbers', function(done) {      
+    it('should start maximum processes depending on CPU numbers', function(done) {
       God.prepare({
         pm_exec_path    : path.resolve(process.cwd(), 'test/fixtures/echo.js'),
         pm_err_log_path : path.resolve(process.cwd(), 'test/errLog.log'),
@@ -127,7 +127,7 @@ describe('God', function() {
         }, 500);
       });
     });
-    
+
     it('should cron restart', function(done) {
       God.prepare({
         pm_exec_path    : path.resolve(process.cwd(), 'test/fixtures/args.js'),

--- a/test/satan.mocha.js
+++ b/test/satan.mocha.js
@@ -52,9 +52,9 @@ describe('Satan', function() {
         assert(err == null);
         methods.should.have.property('prepare');
         methods.should.have.property('list');
-        methods.should.have.property('stopId');
+        methods.should.have.property('sendSignalToProcessId');
         methods.should.have.property('stopAll');
-        methods.should.have.property('stopProcessName');
+        methods.should.have.property('sendSignalToProcessName');
         methods.should.have.property('killMe');
         methods.should.have.property('daemonData');
         done();


### PR DESCRIPTION
## The goal

Add the possibility to send a signal to the workers selected by name or by id.
# The implementation

The PR adds a new command `sendSignal <signal> <id|name>`.
The implementation leverages on the methods that stop a process since those methods send a KILL signal to the process.

I replaced everywhere the method `stopProcessId` by `sendSignalToProcessId` and `stopProcessName` by `sendSignalToProcessName`.

please give feedback and discuss.
