### PR TITLE
clear tabs esc after process spinner

### DIFF
--- a/lib/CliUx.js
+++ b/lib/CliUx.js
@@ -66,7 +66,7 @@ UX.processing = {
     play(frames, 70);
   },
   stop : function() {
-    process.stdout.write('\u001b[2K');
+    process.stdout.write('\u001b[0G\u001b[2K');
     clearInterval(timer);
   }
 };


### PR DESCRIPTION
Avoids cli-table corruption on next line.
As an illustration, Please, see cli-table after "pm2 stop all" 
![cli-table-shift](https://f.cloud.github.com/assets/1692611/1543834/ee690d9c-4d5d-11e3-91f2-d6500e9bffed.png)
