### PR TITLE
Ensure error logs are flushed before quitting a process

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -98,8 +98,14 @@ function exec(script, outFile, errFile) {
           type : 'uncaughtException',
           stack : err.stack
         });
-        
-        process.exit(cst.CODE_UNCAUGHTEXCEPTION);
+
+        if (stderr.write("Exiting\n")) {
+          process.exit(cst.CODE_UNCAUGHTEXCEPTION);
+        } else {
+          stderr.on('drain', function() {
+            process.exit(cst.CODE_UNCAUGHTEXCEPTION);
+          });
+        }
       });
 
 


### PR DESCRIPTION
This fixes #176
