### PR TITLE
Add getSystemData call

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -10,6 +10,7 @@ var cst     = require('../constants.js');
 var util    = require('util');
 var log     = require('debug')('pm2:god');
 var fs      = require('fs');
+var os      = require('os');
 
 var EventEmitter2 = require('eventemitter2').EventEmitter2;
 
@@ -374,6 +375,24 @@ God.getMonitorData = function(env, cb) {
   };
 
   ex(processes.length - 1);
+};
+
+God.getSystemData = function(env, cb) {
+  God.getMonitorData(env, function(err, processes) {
+    cb(err, {
+      system: {
+        hostname: os.hostname(),
+        uptime: os.uptime(),
+        cpus: os.cpus(),
+        load: os.loadavg(),
+        memory: {
+          free: os.freemem(),
+          total: os.totalmem()
+        }
+      },
+      processes: processes
+    });
+  });
 };
 
 God.getFormatedProcesses = function() {

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -108,6 +108,7 @@ Satan.remoteWrapper = function() {
   server.expose({
     prepare            : God.prepare,
     getMonitorData     : God.getMonitorData,
+    getSystemData      : God.getSystemData,
     startProcessId     : God.startProcessId,
     stopProcessId      : God.stopProcessId,
     stopProcessName    : God.stopProcessName,

--- a/test/god.mocha.js
+++ b/test/god.mocha.js
@@ -21,6 +21,7 @@ describe('God', function() {
     God.should.have.property('prepare');
     God.should.have.property('getProcesses');
     God.should.have.property('getMonitorData');
+    God.should.have.property('getSystemData');
     God.should.have.property('getFormatedProcesses');
     God.should.have.property('checkProcess');
     God.should.have.property('stopAll');

--- a/test/satan.mocha.js
+++ b/test/satan.mocha.js
@@ -52,6 +52,7 @@ describe('Satan', function() {
         assert(err == null);
         methods.should.have.property('prepare');
         methods.should.have.property('getMonitorData');
+        methods.should.have.property('getSystemData');
         methods.should.have.property('stopProcessId');
         methods.should.have.property('stopAll');
         methods.should.have.property('stopProcessName');
@@ -63,6 +64,13 @@ describe('Satan', function() {
     it('should get an empty process list', function(done) {
       Satan.executeRemote('getMonitorData', {}, function(err, res) {
         assert(res.length === 0);
+        done();
+      });
+    });
+
+    it('should get an empty process list from system data', function(done) {
+      Satan.executeRemote('getSystemData', {}, function(err, res) {
+        assert(res.processes.length === 0);
         done();
       });
     });
@@ -84,6 +92,13 @@ describe('Satan', function() {
     it('should list 4 processes', function(done) {
       Satan.executeRemote('getMonitorData', {}, function(err, res) {
         assert(res.length === 4);
+        done();
+      });
+    });
+
+    it('should list 4 processes via system data', function(done) {
+      Satan.executeRemote('getSystemData', {}, function(err, res) {
+        assert(res.processes.length === 4);
         done();
       });
     });


### PR DESCRIPTION
I've taken the changes from pull request #36 and created an npm module called [pm2-web](https://npmjs.org/package/pm2-web).

It works but in order to enable multi-host pm2 monitoring, I need more information than the getMonitorData RPC call returns.

This pull request adds a new call named getSystemData that returns the hostname, cpu info, memory, load, etc, along with the process information and tests for the same.

Happy to discuss these changes and make any amends.
