### PR TITLE
emit process:exception with the full err

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -114,7 +114,7 @@ function nodeApp(pm2_env, cb){
   clu.on('message', function(msg) {
     switch (msg.type) {
     case 'uncaughtException':
-      God.bus.emit('process:exception', {process : clu, err : msg.err});
+      God.bus.emit('process:exception', {process : clu, msg : msg.stack, err : msg.err});
       break;
     default: // Permits to send message to external from the app
       God.bus.emit(msg.type ? msg.type : 'msg', msg);

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -96,6 +96,7 @@ function exec(script, outFile, errFile) {
         // Notify master that an uncaughtException has been catched
         process.send({
           type : 'uncaughtException',
+          stack : err.stack,
           err  : {
               type: err.type,
               stack: err.stack,


### PR DESCRIPTION
Hello,

This PR exposes the "full" error on uncaughtException allowing seamless integration with already existing handlers. What do you think about it?

example

```
var ipm2 = require('pm2-interface')();

ipm2.on('ready', function() {
    console.log('Connected to pm2');
    ipm2.bus.on('process:exception', function(event){
        existingHandler(event.err);
    });
});
```
