### PR TITLE
add God method for sending message to process

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -699,3 +699,66 @@ God.killMe = function(env, cb) {
     process.exit(cst.SUCCESS_EXIT);
   }, 1000);
 };
+
+
+
+/**
+ * Send Message to Process by id or name
+ */
+
+God.msgProcess = function(opts, cb) {
+
+  var msg = opts.msg || {};
+
+  if ("id" in opts) {
+    var id = opts.id;
+    if (!(id in God.clusters_db))
+      return cb(new Error({msg : "PM ID unknown"}), {});
+    var proc = God.clusters_db[id];
+
+    if (proc.pm2_env.status == cst.ONLINE_STATUS) {
+      /*
+       * Send message
+       */
+      proc.send(msg);
+      return cb(null, "message sent");
+    }
+    else
+      return cb(new Error({msg : "PM ID offline"}), {});
+    return false;
+  }
+
+  else if ("name" in opts) {
+    /*
+     * As names are not unique in case of cluster, this
+     * will send msg to all process matching  "name"
+     */
+    var name = opts.name;
+    var arr = Object.keys(God.clusters_db);
+    var sent = 0;
+
+    (function ex(arr) {
+      if (arr[0] == null) return cb(null, "sent " + sent + " messages");
+
+      var id      = arr[0];
+      var proc_env = God.clusters_db[id].pm2_env;
+
+      if (p.basename(proc_env.pm_exec_path) == name || proc_env.name == name) {
+        if (proc_env.status == cst.ONLINE_STATUS) {
+          God.clusters_db[id].send(msg);
+          sent++;
+          arr.shift();
+          return ex(arr);
+
+        }
+      }
+      else {
+        arr.shift();
+        return ex(arr);
+      }
+      return false;
+    })(arr);
+  }
+
+  else return cb(new Error({msg : "method requires name or id field"}), {});
+}

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -123,6 +123,7 @@ Satan.remoteWrapper = function() {
     restartProcessName : God.restartProcessName,
     deleteProcessName  : God.deleteProcessName,
     deleteProcessId    : God.deleteProcessId,
+    msgProcess         : God.msgProcess,
     deleteAll          : God.deleteAll
   });
 


### PR DESCRIPTION
Add a method to God which will allow messaging to process from external RPC calls. This is useful for adding generic code monitoring into the PM2 system (number of connected clients, etc.) or using PM2 to control code flow more directly. This is then available to external tools such as [pm2-interface](https://github.com/Unitech/pm2-interface).

Example:
in your process script:

``` javascript
process.on("message", function (msg) {
  if ( "type" in msg && msg.type === "god:heap" ) {
    var heap = process.memoryUsage().heapUsed
    process.send({type:"process:heap", heap:heap})
  }
})
```

Then in some monitoring process (using pm2-interface in this case)

``` javascript
ipm2.bus.on('process:*', function(event, data) {

  if (event === "heap" && "heap" in data) {
    console.log("process heap:", data)
  }
  ...
}

var msg = {type:"god:heap", data:x}
ipm2.rpc.msgProcess({name:"worker", msg:msg}, function (err, res) {
  if (err) console.log(err)
  else console.log(res)
 })
```

returns

``` shell
process heap: { type: 'process:heap', heap: 7000592 }
```
