### PR TITLE
add pm2_id to external msgs to link msg to sending process

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -114,7 +114,7 @@ function nodeApp(pm2_env, cb){
   clu.on('message', function(msg) {
     switch (msg.type) {
     case 'uncaughtException':
-      God.bus.emit('process:exception', {process : clu, msg : msg.stack, err : msg.err});
+      God.bus.emit('process:exception', {process : clu, data : msg.stack, err : msg.err});
       break;
     case 'log:out':
       God.bus.emit('log:out', {process : clu, data : msg.data});
@@ -122,10 +122,8 @@ function nodeApp(pm2_env, cb){
     case 'log:err':
       God.bus.emit('log:err', {process : clu, data : msg.data});
       break;
-    default: // Permits to send message to external from the app - include pm2_id for identification.
-      God.bus.emit(msg.type ? msg.type : 'msg', {
-        pm_id: ("pm_id" in clu.pm2_env) ? clu.pm2_env.pm_id : ""
-      , msg: msg });
+    default: // Permits to send message to external from the app
+      God.bus.emit(msg.type ? msg.type : 'process:msg', {process : clu, data : msg });
     }
   });
 


### PR DESCRIPTION
It is useful to be able to link messages sent on the external bus to a particular process - especially in cluster mode where a script does not have any internally distinguishable state. Also useful coupled with [this feature](https://github.com/Unitech/pm2/pull/214) allowing 2-way messaging over the PM2 subsystem.
