### PR TITLE
Add ability to specify env variables in JSON

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -31,9 +31,8 @@ Common.resolveAppPaths = function(app, cwd, outputter) {
 
   cwd = cwd || process.cwd();
 
-  app.env = {
-    pm_cwd: cwd
-  };
+  app.env = app.env || {};
+  app.env.pm_cwd = cwd;
 
   if (!('exec_mode' in app)) app['exec_mode'] = 'cluster_mode';
 


### PR DESCRIPTION
By not overwriting the env object in the JSON, it allow us to specify
env variables directly in the JSON.

Example:

``` json
[
  {
    "name": "my-awesome-app",
    "script": "./lib/app.js",
    "port": "10000",
    "env": {
      "NODE_ENV": "production",
      "AWESOME_SERVICE_API_TOKEN": "xxx"
    }
  }
]
```

Typically, I wanted to specify the NODE_ENV and other specific configuration, like keys/token for external services.
