### PR TITLE
HttpInterface now sends CORS headers to allow browsers to fetch data dir...

### DIFF
--- a/lib/HttpInterface.js
+++ b/lib/HttpInterface.js
@@ -12,8 +12,13 @@ var cst   = require('../constants.js');
 var p     = require('path');
 
 http.createServer(function (req, res) {
+  // Add CORS headers to allow browsers to fetch data directly
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With');
+  res.setHeader('Access-Control-Allow-Methods', 'GET');      
+
   // We always send json
-  res.writeHead(200, {'Content-Type': 'application/json'});
+  res.setHeader('Content-Type','application/json');
 
   var path = urlT.parse(req.url).pathname;
 
@@ -35,13 +40,15 @@ http.createServer(function (req, res) {
                },
         processes: data_proc
       };
-      
+
+      res.statusCode = 200;
       res.write(JSON.stringify(data));
       return res.end();
     });
   }
   else {
     // 404
+    res.statusCode = 404;
     res.write(JSON.stringify({err : '404'}));
     return res.end();
   };


### PR DESCRIPTION
Currently it's not possible for a web browser to directly fetch data from pm2's http interface (for example, using an AJAX request). This is because of cross origin resource sharing security restrictions built in to most browser. This patch adds CORS headers to all pm2 http interface responses, so that browser can query pm2 directly. 

Additionally, a request to an invalid path now correctly returns a 404 response.
