### PR TITLE
Added 'mode' and 'port' to the 'serious display'.

### DIFF
--- a/lib/CliUx.js
+++ b/lib/CliUx.js
@@ -18,6 +18,8 @@ UX.miniDisplay = function(list) {
     console.log('pid : %s', l.pid);
     console.log('pm2 id : %s', l.pm2_env.pm_id);
     console.log('status : %s', status);
+    console.log('mode : %s', mode);
+    console.log('port : %s', port);
     console.log('restarted : %d', l.pm2_env.restart_time ? l.pm2_env.restart_time : 0);
     console.log('uptime : %s', (l.pm2_env.pm_uptime && status == 'online') ? timeSince(l.pm2_env.pm_uptime) : 0);
     console.log('memory usage : %s', l.monit ? UX.bytesToSize(l.monit.memory, 3) : '');


### PR DESCRIPTION
Needed "mode" and "port" instance details also on the more-easy-to-parse "serious display" output. The corresponding variables had already been defined, but for some reason they weren't included in the output.
