### PR TITLE
adjust logical when process got an uncaughtException event #262

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -91,9 +91,7 @@ function exec(script, outFile, errFile) {
                                 };
                               })(process.stdout.write);
 
-      process.on('uncaughtException', function(err) {
-        stderr.write(err.stack);
-
+      process.on('uncaughtException', function uncaughtListener(err) {
         // Notify master that an uncaughtException has been catched
         process.send({
           type : 'uncaughtException',
@@ -106,7 +104,12 @@ function exec(script, outFile, errFile) {
             }
         });
 
-        process.exit(cst.CODE_UNCAUGHTEXCEPTION);
+        if (!process.listeners('uncaughtException').filter(function (listener) {
+            return listener !== uncaughtListener;
+        }).length) {
+            stderr.write(err.stack);
+            process.exit(cst.CODE_UNCAUGHTEXCEPTION);
+        }
       });
 
 


### PR DESCRIPTION
Prevent process exit and print a stack trace when encounter
uncaughtexception if there is other listeners on `uncaughtException`
event.
