### PR TITLE
Adds the current time to the getSystemData RPC method

### DIFF
--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -59,7 +59,8 @@ module.exports = function(God) {
           memory: {
             free: os.freemem(),
             total: os.totalmem()
-          }
+          },
+          time: Date.now()
         },
         processes: processes
       });


### PR DESCRIPTION
When the time is wrong on the server running pm2 inconsistencies can occur when calculating process uptimes, etc as uptimes are reported by pm2 as the time the process started, rather than how many (milli)seconds it's been running for.

This pull request adds what the server thinks the current time is to the getSystemData RPC call so consumers can present the data as the server sees it.
