### PR TITLE
Added the ability to accept JSON via a pipe from standard input.

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -50,25 +50,39 @@ commander.version(pkg.version)
 //
 // Start command
 //
-commander.command('start <script|json_file>')
-  .description('start specific part')
+commander.command('start <script|json_file|stdin(-)>')
+  .description('start specific processes')
   .action(function(cmd) {
-    if (cmd.indexOf('.json') > 0)
-      CLI.startFromJson(cmd);
+    if (cmd == "-") {
+      process.stdin.resume();
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', function (cmd) {
+        process.stdin.pause();
+        CLI.startFromJson(cmd, 'pipe');
+      });
+    } else if (cmd.indexOf('.json') > 0)
+      CLI.startFromJson(cmd, 'file');
     else
-      CLI.startFile(cmd);
+      CLI.startFile(cmd,'file');
   });
 
 //
 // Stop specific id
 //
-commander.command('stop <pm2_id|name|all|json_file>')
+commander.command('stop <pm2_id|name|all|json_file|stdin(-)>')
   .description('stop specific process pm2 id or script name (set with --name or script name)')
   .action(function(param) {
     UX.processing.start();
 
-    if (param.indexOf('.json') > 0)
-      CLI.actionFromJson('stopProcessName', param);
+    if (param == "-") {
+      process.stdin.resume();
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', function (param) {
+        process.stdin.pause();
+        CLI.actionFromJson('stopProcessName', param, 'pipe');
+      });
+    } else if (param.indexOf('.json') > 0)
+      CLI.actionFromJson('stopProcessName', param, 'file');
     else if (param == 'all')
       CLI.stopAll();
     else if (isNaN(parseInt(param))) {
@@ -82,13 +96,20 @@ commander.command('stop <pm2_id|name|all|json_file>')
 //
 // Stop All processes
 //
-commander.command('restart <pm2_id|name|all|json_file>')
+commander.command('restart <pm2_id|name|all|json_file|stdin(-)>')
   .description('restart processes by id/name/all or by apps defined in json file')
   .action(function(param) {
     UX.processing.start();
 
-    if (param.indexOf('.json') > 0)
-      CLI.actionFromJson('restartProcessName', param);
+    if (param == "-") {
+      process.stdin.resume();
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', function (param) {
+        process.stdin.pause();
+        CLI.actionFromJson('restartProcessName', param, 'pipe');
+      });
+    } else if (param.indexOf('.json') > 0)
+      CLI.actionFromJson('restartProcessName', param, 'file');
     if (param == 'all')
       CLI.restartAll();
     else if (isNaN(parseInt(param))) {

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -100,9 +100,13 @@ CLI.startFile = function(script) {
  * Use a RPC method on the json file
  * @param {string} action RPC Method
  */
-CLI.actionFromJson = function(action, file) {
-  var data = fs.readFileSync(file);
-  var appConf = JSON.parse(data);
+CLI.actionFromJson = function(action, file, jsonVia) {
+  if (jsonVia == 'pipe')
+    var appConf = JSON.parse(file);
+  else {
+    var data = fs.readFileSync(file);
+    var appConf = JSON.parse(data);
+  }
 
   if (!Array.isArray(appConf)) appConf = [appConf]; //convert to array
 
@@ -132,9 +136,13 @@ CLI.actionFromJson = function(action, file) {
   });
 };
 
-CLI.startFromJson = function(cmd) {
-  var data = fs.readFileSync(cmd);
-  var appConf = JSON.parse(data);
+CLI.startFromJson = function(cmd,jsonVia) {
+  if (jsonVia == 'pipe')
+    var appConf = JSON.parse(cmd);
+  else {
+    var data = fs.readFileSync(cmd);
+    var appConf = JSON.parse(data);
+  }
 
   if (!Array.isArray(appConf)) appConf = [appConf]; //convert to array
 


### PR DESCRIPTION
Added the ability to pipe JSON in. This is useful specifically when using Fabric to manage remote servers running pm2, as this way the JSON which is already available for the control script can simply be piped in without having to transfer a separate JSON file to the remote. Used the UNIX-standard hyphen to indicate an stdinput stream. Does not interfere with other command line options. Now something like this is possible (e.g. in bash):

```
#!/bin/bash

read -d '' my_json <<_EOF_ 
[{
    "name"       : "app1",
    "script"     : "/home/projects/pm2_nodetest/app.js",
    "instances"  : "4",
    "error_file" : "./logz/child-err.log",
    "out_file"   : "./logz/child-out.log",
    "pid_file"   : "./logz/child.pid",
    "exec_mode"  : "cluster_mode",
    "port"       : 4200
}]
_EOF_

echo $my_json | pm2 start -
```
