### PR TITLE
Support coffee-script 1.7.0

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -7,7 +7,7 @@ var p      = require('path');
 var cst    = require('../constants');
 var worker = require('cluster').worker;
 
-require('coffee-script');
+require('coffee-script/register');
 
 /**
  * Main entrance to wrap the desired code

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "axon"           : "1.0.0",
     "cron"           : "1.0.1",
     "colors"         : "0.6.2",
-    "coffee-script"  : "*",
+    "coffee-script"  : "1.7.0",
     "eventemitter2"  : "0.4.13",
     "debug"          : "*",
     "async"          : "0.2.9"


### PR DESCRIPTION
Start from `1.7.0`, coffee-script no longer automatically register the compiler.
Please see http://coffeescript.org/#changelog for detail.
