### PR TITLE
execute status as $USER

### DIFF
--- a/lib/scripts/pm2-init-centos.sh
+++ b/lib/scripts/pm2-init-centos.sh
@@ -60,7 +60,7 @@ reload() {
 
 status() {
     echo "Status for $NAME:"
-    $PM2 list
+    super $PM2 list
     RETVAL=$?
 }
 

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -51,7 +51,7 @@ reload() {
 
 status() {
     echo "Status for $NAME:"
-    $PM2 list
+    super $PM2 list
     RETVAL=$?
 }
 


### PR DESCRIPTION
Executing `service pm2-init.sh status` starts pm2 service as current user instead of as `$USER` defined in service script.
