### PR TITLE
Restart by path? No, I really don't need it.

### DIFF
--- a/lib/God/Methods.js
+++ b/lib/God/Methods.js
@@ -68,9 +68,7 @@ module.exports = function(God) {
     var arr = [];
 
     for (var key in db) {
-      if (p.basename(God.clusters_db[key].pm2_env.pm_exec_path) == name ||
-          p.basename(God.clusters_db[key].pm2_env.pm_exec_path) == p.basename(name) ||
-          God.clusters_db[key].pm2_env.name == name) {
+      if (God.clusters_db[key].pm2_env.name == name) {
         arr.push(db[key]);
       }
     }

--- a/test/cli2.sh
+++ b/test/cli2.sh
@@ -49,13 +49,12 @@ cd ../..
 echo "Change path try to exec"
 $pm2 start test/fixtures/echo.js
 should 'should app be online' 'online' 1
-$pm2 stop test/fixtures/echo.js
+$pm2 stop echo
 should 'should app be stopped' 'stopped' 1
 $pm2 start test/fixtures/echo.js
 should 'should app be online' 'online' 1
 
 cd -
-
 
 ########### DELETED STUFF BY ID
 $pm2 kill
@@ -70,15 +69,6 @@ $pm2 kill
 $pm2 start echo.js --name test
 $pm2 delete test
 should 'should has been deleted process by name' "name: 'test'" 0
-
-########### DELETED STUFF BY SCRIPT
-$pm2 kill
-
-$pm2 start echo.js
-$pm2 delete echo.js
-$pm2 list
-should 'should has been deleted process by script' "name: 'echo'" 0
-
 
 ########### OPTIONS OUTPUT FILES
 $pm2 kill

--- a/test/fork.sh
+++ b/test/fork.sh
@@ -11,7 +11,7 @@ $pm2 kill
 $pm2 start echo.js -x
 should 'should has forked app' 'fork_mode' 1
 
-$pm2 restart echo.js
+$pm2 restart echo
 should 'should has forked app' 'restart_time: 1' 1
 
 ########### Fork mode

--- a/test/reload.sh
+++ b/test/reload.sh
@@ -15,12 +15,10 @@ $pm2 start child.js -i 4
 should 'should start processes' 'online' 4
 $pm2 restart all
 should 'should restarted be one for all' 'restart_time' 4
-$pm2 restart child.js
-should 'should restart a second time (BY SCRIPT NAME)' 'restart_time: 2' 4
 $pm2 restart child
-should 'should restart a third time (BY NAME)' 'restart_time: 3' 4
+should 'should restart a second time (BY NAME)' 'restart_time: 2' 4
 $pm2 reload all
-should 'should RELOAD a fourth time' 'restart_time: 4' 4
+should 'should RELOAD a third time' 'restart_time: 3' 4
 
 ############### CLUSTER STUFF
 $pm2 kill


### PR DESCRIPTION
Hi, Alex:

`pm2 restart path|scriptname` command exists for a long time, recently I found some issues with this command, for example:

I have a node service (and others) named 'striker' on my server, the startup script is something like '/usr/local/repos/striker/bin/striker', and I deployed two version of this script, which one is 'release' versions and another is 'general availability' version. 

When I start these two service with pm2, it works well.

```
┌────────────┬────┬─────────┬──────┬────────┬──────┬───────────┬────────┬───────────┬───────────────────────────────────────────────┐
│ App Name   │ id │ mode    │ PID  │ status │ port │ Restarted │ Uptime │    memory │ err logs                                      │
├────────────┼────┼─────────┼──────┼────────┼──────┼───────────┼────────┼───────────┼───────────────────────────────────────────────┤
│ striker-ga │ 0  │ cluster │ 6473 │ online │      │         0 │ 3s     │ 22.684 MB │ /Users/tristan/.pm2/logs/striker-ga-err-0.log │
├────────────┼────┼─────────┼──────┼────────┼──────┼───────────┼────────┼───────────┼───────────────────────────────────────────────┤
│ striker    │ 1  │ cluster │ 6481 │ online │      │         0 │ 0s     │ 12.383 MB │ /Users/tristan/.pm2/logs/striker-err-1.log    │
└────────────┴────┴─────────┴──────┴────────┴──────┴───────────┴────────┴───────────┴───────────────────────────────────────────────┘
```

When I restart the release version by name, `pm2 restart striker`, it will restart both two scripts unexpected.

```
┌────────────┬────┬─────────┬──────┬────────┬──────┬───────────┬────────┬───────────┬───────────────────────────────────────────────┐
│ App Name   │ id │ mode    │ PID  │ status │ port │ Restarted │ Uptime │    memory │ err logs                                      │
├────────────┼────┼─────────┼──────┼────────┼──────┼───────────┼────────┼───────────┼───────────────────────────────────────────────┤
│ striker-ga │ 0  │ cluster │ 6975 │ online │      │         1 │ 0s     │ 20.770 MB │ /Users/tristan/.pm2/logs/striker-ga-err-0.log │
├────────────┼────┼─────────┼──────┼────────┼──────┼───────────┼────────┼───────────┼───────────────────────────────────────────────┤
│ striker    │ 1  │ cluster │ 6976 │ online │      │         1 │ 0s     │ 11.992 MB │ /Users/tristan/.pm2/logs/striker-err-1.log    │
└────────────┴────┴─────────┴──────┴────────┴──────┴───────────┴────────┴───────────┴───────────────────────────────────────────────┘
```

I found this issue was caused by 'God/Methods.findByName' function. I wonder how many people will use `restart` command with path or script name. So I removed `find by path/script name` in `findByName` function, just keep it **simple** and **clear**. What's your opinion?

Cheers!
