### PR TITLE
Adds --node-args command line option to pass options to node

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -18,6 +18,10 @@ var CLI       = require('../lib/CLI');
 var cst       = require('../constants.js');
 var pkg       = require('../package.json');
 
+function list(val) {
+  return val.split(' ');
+}
+
 commander.version(pkg.version)
   .option('-v --verbose', 'verbose level')
   .option('-s --silent', 'throw less messages', false)
@@ -34,6 +38,7 @@ commander.version(pkg.version)
   .option('-w --write', 'write configuration in local folder')
   .option('--interpreter <interpreter>', 'the interpreter pm2 should use for executing app (bash, python...)')
   .option('--no-daemon', "run pm2 daemon in the foreground if it doesn't exist already")
+  .option('--node-args <node_args>', "space delimited arguments to pass to node in cluster mode - e.g. --node-args=\"--debug=7001 --trace-deprecation\"", list)
   .usage('[cmd] app');
 
 //

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -29,6 +29,8 @@ CLI.startFile = function(script) {
     name : p.basename(script, '.js')
   };
 
+  if (commander.nodeArgs)
+    appConf['nodeArgs'] = commander.nodeArgs;
   if (commander.name)
     appConf['name']            = commander.name;
   if (commander.instances)

--- a/lib/God/ClusterMode.js
+++ b/lib/God/ClusterMode.js
@@ -36,6 +36,10 @@ module.exports = function(God) {
       return cb(new Error('Script ' + pm2_env.pm_exec_path + ' missing'));
     }
 
+    if (pm2_env.nodeArgs && Array.isArray(pm2_env.nodeArgs)) {
+      cluster.settings.execArgv = pm2_env.nodeArgs;
+    }
+
     try {
       clu = cluster.fork(pm2_env);
     } catch(e) { console.error(e); }


### PR DESCRIPTION
This pull request attempts to address #45 - not being able to pass v8/node options to processes managed by pm2.

By way of example it lets you do this sort of thing:

```
$ pm2 start --node-args="--debug=7001 --trace-deprecation" script.js
```

Please let me know what you think.  I'm happy to discuss and make any amends required.
