### PR TITLE
Added a new pm2_env property to provide the full path + filename to the PID file of each process

### DIFF
--- a/lib/God/Methods.js
+++ b/lib/God/Methods.js
@@ -37,6 +37,7 @@ module.exports = function(God) {
 
     for (var key in db) {
       if (db[key]) {
+        db[key].pm2_env.pm_pid_path_abs=[db[key].pm2_env.pm_pid_path, db[key].pm2_env.pm_id, '.pid'].join('');
         arr.push({
           pid     : db[key].process.pid,
           name    : db[key].pm2_env.name,


### PR DESCRIPTION
This minor change introduces a new property 'pm_pid_path_abs' to pm2_env to contain the full path + the  actual filename to the PID file of the process.  The existing parameter, pm_pid_path, only provides the root path as defined in the JSON configuration when the process is started. Hence, if the parameter is set in JSON, like so:

```
...
"pid_file" : "${INSTALLATION_DIR}/pids/$1-",
...
```

Then the 'pm_pid_path' property in jlist output looks this:

```
...
"pm_pid_path" : "/usr/projects/pm2_nodetest/pids/testapp-",
...
```

The property added by this patch, 'pm_pid_path_abs', provides the full path in jlist output, i.e.:

```
...
"pm_pid_path_abs" : "/usr/projects/pm2_nodetest/pids/testapp-0.pid",
...
```

If the above is unintended output for 'pm_pid_path', you may want to modify its output instead of merging this pull request as-is.
