### PR TITLE
Adds an RPC method to report the pm2 version number

### DIFF
--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -19,6 +19,7 @@ var os            = require('os');
 var p             = path;
 var Common        = require('../Common');
 var cst           = require('../../constants.js');
+var pkg           = require('../../package.json');
 
 module.exports = function(God) {
 
@@ -406,4 +407,8 @@ module.exports = function(God) {
     else return cb(new Error({msg : 'method requires name or id field'}), {});
     return false;
   };
+
+  God.getVersion = function(env, cb) {
+    cb(null, pkg.version);
+  }
 };

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -140,7 +140,8 @@ Satan.remoteWrapper = function() {
     deleteAll               : God.deleteAll,
     ping                    : God.ping,
     sendSignalToProcessId   : God.sendSignalToProcessId,
-    sendSignalToProcessName : God.sendSignalToProcessName
+    sendSignalToProcessName : God.sendSignalToProcessName,
+    getVersion              : God.getVersion
   });
 
   /**

--- a/test/god.mocha.js
+++ b/test/god.mocha.js
@@ -271,4 +271,11 @@ describe('God', function() {
       });
     });
   });
+
+  it('should report pm2 version', function(done) {
+    God.getVersion({}, function(err, version) {
+      version.should.not.be.null;
+      done();
+    });
+  });
 });


### PR DESCRIPTION
...and a unit test too.  This is in order to let people know when the version of pm2 they are using is out of date and doesn't support x y or z feature and resolves https://github.com/Unitech/pm2-interface/issues/11
