### PR TITLE
-added a "getValOrDefault" convenience function and calls for optionally...

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -51,6 +51,27 @@ require('./God/ClusterMode.js')(God);
 require('./God/Reload')(God);
 require('./God/ActionMethods')(God);
 
+// hooks for calling custom code in the event of a fail.
+/*
+ * example / how to use - when launching with options declared in foo.json, add a line to foo.json like:
+ *     "failHandlerScript" : "/somePathToFile/executeWhenAppExits.js"
+ *
+ * then in executeWhenAppExits.js, define a function like this to implement specific handling for crashes/restarts:
+ *
+ *  exports.appExited = function(scriptPath, scriptId, exitCode, restartCount, isBeingStoppedForGood) {
+ *       console.log("scriptPath '" + scriptPath + "' #" + scriptId + ", exit code [" + exitCode + "] exited...");
+ *       if (isBeingStoppedForGood) {
+ *           console.log("app has failed enough that pm2 will NOT restart it again; send an email or something to let interested parties know");
+ *       } else {
+ *           console.log("app died but restart #" + restartCount + " has automatically been done by pm2.");
+ *       }
+ *  };
+ *
+ */
+var attemptCustomExitFxnLoading = true;
+var customExitFxn;
+
+
 /**
  * Forced entry to initialize cluster monitoring
  */
@@ -67,6 +88,10 @@ require('./God/ActionMethods')(God);
   });
 })();
 
+function getValOrDefault(val, defaultVal) {
+  return (val != null) ? val : defaultVal;
+}
+
 /**
  * Handle logic when a process exit (Node or Fork)
  */
@@ -75,6 +100,19 @@ function handleExit(clu, exit_code) {
               clu.pm2_env.pm_exec_path,
               clu.pm2_env.pm_id,
               exit_code);
+
+  if (attemptCustomExitFxnLoading) {
+    var failHandlerPath = getValOrDefault(clu.pm2_env.failHandlerScript, null);
+    if (failHandlerPath != null) {
+      try {
+        var failHandlerModule = require(failHandlerPath);
+        customExitFxn = failHandlerModule.appExited;
+      } catch (e) {
+        console.log("A failHandler script was specified in configuration but could not be found: [" + e + "]");
+      }
+    }
+    attemptCustomExitFxnLoading = false;
+  }
 
   var stopping    = (clu.pm2_env.status == cst.STOPPING_STATUS || clu.pm2_env.status == cst.ERRORED_STATUS) ? true : false;
   var overlimit   = false;
@@ -93,16 +131,20 @@ function handleExit(clu, exit_code) {
   /**
    * Avoid infinite reloop if an error is present
    */
-  // If the process has been created less than 15seconds ago
-  if ((Date.now() - clu.pm2_env.created_at) < 15000) {
-    // And if the process has an uptime less than a second
-    if ((Date.now() - clu.pm2_env.pm_uptime) < (1000 || clu.pm2_env.min_uptime)) {
+  var unstableRestartsMonitorPeriod = getValOrDefault(clu.pm2_env.unstable_restarts_monitor_period, 15000);
+  var minUptime = getValOrDefault(clu.pm2_env.min_uptime, 1000);
+  var maxAllowedUnstableRestarts = getValOrDefault(clu.pm2_env.max_allowed_unstable_restarts, 15);
+
+  // If the process has been created less than 15 (default, can be overriden) seconds ago
+  if ((Date.now() - clu.pm2_env.created_at) < unstableRestartsMonitorPeriod) {
+    // And if the process has an uptime less than a second (default, can be overridden)
+    if ((Date.now() - clu.pm2_env.pm_uptime) < minUptime) {
       // Increment unstable restart
       clu.pm2_env.unstable_restarts += 1;
     }
 
-    if (clu.pm2_env.unstable_restarts >= 15) {
-      // Too many unstable restart in less than 15 seconds
+    if (clu.pm2_env.unstable_restarts > maxAllowedUnstableRestarts) {
+      // Too many unstable restart in less than seconds threshold described above
       // Set the process as 'ERRORED'
       // And stop to restart it
       clu.pm2_env.status = cst.ERRORED_STATUS;
@@ -122,6 +164,10 @@ function handleExit(clu, exit_code) {
     clu.pm2_env.restart_time = clu.pm2_env.restart_time + 1;
 
   if (!stopping && !overlimit) God.executeApp(clu.pm2_env);
+
+  if (customExitFxn) {
+    customExitFxn(clu.pm2_env.pm_exec_path, clu.pm2_env.pm_id, exit_code, clu.pm2_env.unstable_restarts, overlimit);
+  }
 };
 
 


### PR DESCRIPTION
Made two main changes in this fork. Hopefully I am following proper github etiquette here; if not I apologize, this is my first pull request:
1. I think I found a bug in God.js where clu.pm2_env.min_uptime configuration value was never being used; code was doing something like "if (1000 || min_uptime)" instead of "if (min_uptime || 1000)", so the 1000 was always being used. Fixed that, added a new convenience method for using default config values, and made a few other changes to make the unstable restart monitor period (previously hardcoded at 15000 ms) and the max number of allowable unstable restarts (previously hardcoded at 15) so that they could be specified in the json configuration file.
2. added a way to specify some customized code that will execute when pm2 detects that an app has crashed/exited. The motivation here was so that you could do satisfy a requirement like "email site admins if the app fatally crashes, but do something else if it crashed but pm2 did a restart." I didn't see an existing facility for this type of behavior but if it exists then ignore this pull!

Anyway way it works is, you can optionally specify the path to a Node script in the pm2 configuration file. pm2 will attempt to require that module and will look for an exported function "appExited" within it. When pm2 detects a crash/exit, it will call that function and pass in the details (path, id, exit code, numRestarts, is the app being stopped for good) as arguments, and the custom code in the user's script can do whatever is appropriate. I think this is ok from a security standpoint but see what you think. I also readily admit that this may not be a good fit for every pm2 use case, like using it to monitor multiple several different node scripts or using clustering, so it's possible this introduces problems in one of those areas. I think it's useful functionality but may not be the direction you want to take.

Hopefully some of this is helpful. Thx.
