### PR TITLE
Corrected non-existent process dump file handling on resurrect.

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -294,13 +294,11 @@ CLI.ping = function() {
 
 CLI.resurrect = function() {
   try {
-    fs.existsSync(cst.DUMP_FILE_PATH);
+    var apps = fs.readFileSync(cst.DUMP_FILE_PATH);
   } catch(e) {
-    console.error(cst.PREFIX_MSG + 'No processes saved file DUMP doesnt exist');
-    return processes.exit(cst.ERROR_EXIT);
+    console.error(cst.PREFIX_MSG + 'No processes saved; DUMP file doesn\'t exist');
+    return exitCli(cst.ERROR_EXIT);
   }
-
-  var apps = fs.readFileSync(cst.DUMP_FILE_PATH);
 
   (function ex(apps) {
     if (!apps[0]) return speedList();


### PR DESCRIPTION
This patch fixes the handling of a non-existent process dump file (`~/.pm2/dump.pm2`). The try.. catch block was not catching the error from `fs.readFileSync` (nor should `fs.readFileSync` be used anymore [per Node API docs](http://nodejs.org/api/fs.html#fs_fs_exists_path_callback)), and so the process exited ungracefully with an error when the dump file wasn't there. Also, `process.exit` was undefined, so I used `exitCli` instead (as in other CLI methods).
