### PR TITLE
fix linter errors (undefined variables mostly)

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -9,7 +9,7 @@ var util = require('util');
 
 // Dont change this or the pm2 could not load custom_options.sh because of
 // header in bin/pm2
-DEFAULT_FILE_PATH = p.resolve(process.env.HOME, '.pm2');
+var DEFAULT_FILE_PATH = p.resolve(process.env.HOME, '.pm2');
 
 var default_conf = {
   DEFAULT_FILE_PATH  : DEFAULT_FILE_PATH,

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -1,7 +1,7 @@
 
 var commander            = require('commander');
 var fs                   = require('fs');
-var path                 = p = require('path');
+var path                 = require('path');
 var util                 = require('util');
 var watch                = require('watch');
 var async                = require('async');
@@ -15,6 +15,7 @@ var cst                  = require('../constants.js');
 var pkg                  = require('../package.json');
 var extItps              = require('./interpreter.json');
 var InteractorDaemonizer = require('./InteractorDaemonizer');
+var p                    = path;
 
 var CLI = module.exports = {};
 require('colors');
@@ -129,7 +130,6 @@ CLI.actionFromJson = function(action, file, jsonVia) {
       if (err)
         console.error(err);
       console.log(cst.PREFIX_MSG + 'Stopping process by name ' + name);
-      delete name;
       next();
     });
 
@@ -299,7 +299,7 @@ CLI.resurrect = function() {
     fs.existsSync(cst.DUMP_FILE_PATH);
   } catch(e) {
     console.error(cst.PREFIX_MSG + 'No processes saved file DUMP doesnt exist');
-    return processes.exit(cst.ERROR_EXIT);
+    return process.exit(cst.ERROR_EXIT);
   }
 
   var apps = fs.readFileSync(cst.DUMP_FILE_PATH);

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -3,11 +3,12 @@
  */
 
 var fs        = require('fs');
-var path      = p = require('path');
+var path      = require('path');
 var util      = require('util');
 var cronJob   = require('cron').CronJob;
 
 var cst       = require('../constants.js');
+var p         = path;
 
 /**
  * Common methods (used by CLI and God)
@@ -102,7 +103,7 @@ Common.validateApp = function(appConf, outputter) {
       var cron_test = new cronJob(cron_pattern, function() {
         if (outputter)
           outputter(cst.PREFIX_MSG + 'cron pattern for auto restart detected and valid');
-        delete cron_test;
+        cron_test = undefined;
       });
     } catch(ex) {
       return new Error('Cron pattern is not valid !');

--- a/lib/Interactor.js
+++ b/lib/Interactor.js
@@ -202,7 +202,7 @@ function listen() {
     ipm2a.removeAllListeners();
     ipm2a.disconnect();
     if (ipm2a)
-      delete ipm2a;
+      ipm2a = undefined;
     setTimeout(listen, 1000);
   });
 }

--- a/lib/Monit.js
+++ b/lib/Monit.js
@@ -6,7 +6,8 @@ var multimeter = require('pm2-multimeter');
 var os         = require('os');
 var CliUx      = require('./CliUx');
 var bars       = {};
-var path       = p = require('path');
+var path       = require('path');
+var p          = path;
 require('colors');
 
 // Cst for light programs


### PR DESCRIPTION
#336

I'm not a huge fan of linting tools and strict mode in particular (please don't use it anybody), but `DEFAULT_FILE_PATH` variable available in all child processes, and global short variable `p` sounds like a big deal.

PS: `delete x` is no-op in javascript.
