### PR TITLE
Fixed rendering

### DIFF
--- a/lib/CliUx.js
+++ b/lib/CliUx.js
@@ -110,17 +110,17 @@ UX.bytesToSize = function(bytes, precision) {
   var terabyte = gigabyte * 1024;
 
   if ((bytes >= 0) && (bytes < kilobyte)) {
-    return bytes + ' B ';
+    return bytes + ' B   ';
   } else if ((bytes >= kilobyte) && (bytes < megabyte)) {
-    return (bytes / kilobyte).toFixed(precision) + ' KB';
+    return (bytes / kilobyte).toFixed(precision) + ' KB  ';
   } else if ((bytes >= megabyte) && (bytes < gigabyte)) {
-    return (bytes / megabyte).toFixed(precision) + ' MB';
+    return (bytes / megabyte).toFixed(precision) + ' MB  ';
   } else if ((bytes >= gigabyte) && (bytes < terabyte)) {
-    return (bytes / gigabyte).toFixed(precision) + ' GB';
+    return (bytes / gigabyte).toFixed(precision) + ' GB  ';
   } else if (bytes >= terabyte) {
-    return (bytes / terabyte).toFixed(precision) + ' TB';
+    return (bytes / terabyte).toFixed(precision) + ' TB  ';
   } else {
-    return bytes + ' B ';
+    return bytes + ' B   ';
   }
 };
 


### PR DESCRIPTION
![screen shot 2014-03-23 at 12 06 34 am](https://f.cloud.github.com/assets/3102127/2492531/377c87b8-b238-11e3-9555-a26bf1184bd0.png)
When passing from a bigger number of chars status to a fewer char, the last chars stays on the command line. Adding empy space erases it.

This is a VERY SMALL bug, but it annoys me =)
