### PR TITLE
Allow sending of SIGUSR2 to initiate a reload of all log files

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -64,64 +64,79 @@ function exec(script, outFile, errFile) {
 
   var stderr, stdout;
 
-  stdout = fs.createWriteStream(outFile, { flags : 'a' });
+  process.on('message', function (msg) {
+    if (msg.type === 'log:reload') {
+      stdout.end();
+      stderr.end();
+      startLogging(function () {
+        console.log('Reloading log...');
+      });
+    }
+  });
 
-  stdout.on('open', function() {
-    stderr = fs.createWriteStream(errFile, { flags : 'a' });
-    stderr.on('open', function() {
+  function startLogging(callback) {
+    stdout = fs.createWriteStream(outFile, { flags : 'a' });
 
-      process.stderr.write = (function(write) {
-                                return function(string, encoding, fd) {
-                                  stderr.write(string);
-                                  process.send({
-                                    type : 'log:err',
-                                    data : string
-                                  });
-                                };
-                              }
-                             )(process.stderr.write);
+    stdout.on('open', function() {
+      stderr = fs.createWriteStream(errFile, { flags : 'a' });
+      stderr.on('open', function() {
 
-      process.stdout.write = (function(write) {
-                                return function(string, encoding, fd) {
-                                  stdout.write(string);
-                                  process.send({
-                                    type : 'log:out',
-                                    data : string
-                                  });
-                                };
-                              })(process.stdout.write);
+        process.stderr.write = (function(write) {
+                                  return function(string, encoding, fd) {
+                                    stderr.write(string);
+                                    process.send({
+                                      type : 'log:err',
+                                      data : string
+                                    });
+                                  };
+                                }
+                               )(process.stderr.write);
 
-      process.on('uncaughtException', function uncaughtListener(err) {
-        try {
-          stderr.write(err.stack);
-        } catch(e) {
-          stderr.write(err.toString());
-        }
+        process.stdout.write = (function(write) {
+                                  return function(string, encoding, fd) {
+                                    stdout.write(string);
+                                    process.send({
+                                      type : 'log:out',
+                                      data : string
+                                    });
+                                  };
+                                })(process.stdout.write);
+        callback();
+      });
+    });
+  }
 
-        // Notify master that an uncaughtException has been catched
-        process.send({
-          type : 'uncaughtException',
-          stack : err.stack,
-          err  : {
-              type: err.type,
-              stack: err.stack,
-              arguments: err.arguments,
-              message: err.message
-            }
-        });
+  startLogging(function () {
+    process.on('uncaughtException', function uncaughtListener(err) {
+      try {
+        stderr.write(err.stack);
+      } catch(e) {
+        stderr.write(err.toString());
+      }
 
-        if (!process.listeners('uncaughtException').filter(function (listener) {
-            return listener !== uncaughtListener;
-        }).length) {
-          setTimeout(function() {
-            process.exit(cst.CODE_UNCAUGHTEXCEPTION);
-          }, 100);
-        }
+      // Notify master that an uncaughtException has been catched
+      process.send({
+        type : 'uncaughtException',
+        stack : err.stack,
+        err  : {
+            type: err.type,
+            stack: err.stack,
+            arguments: err.arguments,
+            message: err.message
+          }
       });
 
-      // Get the script & exec
-      require(script);
+      if (!process.listeners('uncaughtException').filter(function (listener) {
+          return listener !== uncaughtListener;
+      }).length) {
+        setTimeout(function() {
+          process.exit(cst.CODE_UNCAUGHTEXCEPTION);
+        }, 100);
+      }
     });
+
+    // Get the script & exec
+    require(script);
   });
 
 };

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -59,7 +59,8 @@ Satan.start = function(noDaemonMode) {
  * Daemon part
  *
  */
-Satan.processStateHandler = function() {
+Satan.processStateHandler = function(God) {
+
   function gracefullExit() {
     console.log('pm2 has been killed by signal');
     try {
@@ -67,6 +68,16 @@ Satan.processStateHandler = function() {
     } catch(e){}
     process.exit(0);
   }
+
+  function reloadLogs() {
+    console.log('Reloading logs...');
+    var processIds = Object.keys(God.clusters_db);
+    processIds.forEach(function (id) {
+      var cluster = God.clusters_db[id];
+      cluster.send({type:'log:reload'})
+    });
+  }
+
   try {
     fs.writeFileSync(cst.PM2_PID_FILE_PATH, process.pid);
   } catch(e){}
@@ -74,10 +85,14 @@ Satan.processStateHandler = function() {
   process.on('SIGTERM', gracefullExit);
   process.on('SIGINT', gracefullExit);
   process.on('SIGQUIT', gracefullExit);
+  process.on('SIGUSR2', reloadLogs);
 };
 
 Satan.remoteWrapper = function() {
-  Satan.processStateHandler();
+  // Only require here because God init himself
+  var God = require('./God');
+
+  Satan.processStateHandler(God);
 
   if (process.env.SILENT == 'true') {
     // Redirect output to files
@@ -94,8 +109,6 @@ Satan.remoteWrapper = function() {
     };
   }
 
-  // Only require here because God init himself
-  var God = require('./God');
 
   // Send ready message to Satan Client
   if (typeof(process.send) === 'function') {


### PR DESCRIPTION
Hello,

I have had a go at adding the ability for a SIGUSR2 signal to be received by the pm2 process which will then initiate all of the child processes to reload their log files. This is in an attempt to solve the logrotate issue mentioned in #114 and #370 without the need to use copytruncate.

If you are happy with the implementation in principle then I will have a go at adding some tests
