### PR TITLE
Allow user to specify the PM2 Home folder using PM2_HOME env

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -7,14 +7,16 @@ var p    = require('path');
 var fs   = require('fs');
 var util = require('util');
 
+var HOME = process.env.PM2_HOME || process.env.HOME;
+
 // Dont change this or the pm2 could not load custom_options.sh because of
 // header in bin/pm2
-var DEFAULT_FILE_PATH = p.resolve(process.env.HOME, '.pm2');
+var DEFAULT_FILE_PATH = p.resolve(HOME, '.pm2');
 
 var default_conf = {
   DEFAULT_FILE_PATH  : DEFAULT_FILE_PATH,
-  PM2_LOG_FILE_PATH  : p.join(p.resolve(process.env.HOME, '.pm2'), 'pm2.log'),
-  PM2_PID_FILE_PATH  : p.join(p.resolve(process.env.HOME, '.pm2'), 'pm2.pid'),
+  PM2_LOG_FILE_PATH  : p.join(p.resolve(HOME, '.pm2'), 'pm2.log'),
+  PM2_PID_FILE_PATH  : p.join(p.resolve(HOME, '.pm2'), 'pm2.pid'),
   DEFAULT_PID_PATH   : p.join(DEFAULT_FILE_PATH, 'pids'),
   DEFAULT_LOG_PATH   : p.join(DEFAULT_FILE_PATH, 'logs'),
   DUMP_FILE_PATH     : p.join(DEFAULT_FILE_PATH, 'dump.pm2'),
@@ -54,8 +56,8 @@ var default_conf = {
 
   REMOTE_PORT        : 3900,
   REMOTE_HOST        : 'socket-1.pm2.io',
-  INTERACTOR_LOG_FILE_PATH : p.join(p.resolve(process.env.HOME, '.pm2'), 'interactor.log'),
-  INTERACTOR_PID_PATH : p.join(p.resolve(process.env.HOME, '.pm2'), 'interactor.pid'),
+  INTERACTOR_LOG_FILE_PATH : p.join(p.resolve(HOME, '.pm2'), 'interactor.log'),
+  INTERACTOR_PID_PATH : p.join(p.resolve(HOME, '.pm2'), 'interactor.pid'),
   INTERACTOR_RPC_PORT : parseInt(process.env.PM2_INTERACTOR_PORT) || 6668
 };
 

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -225,7 +225,7 @@ CLI.startup = function(platform) {
   var user = commander.user || 'root';
 
   script = script.toString().replace(/%PM2_PATH%/g, process.mainModule.filename);
-  script = script.toString().replace(/%HOME_PATH%/g, process.env.HOME);
+  script = script.toString().replace(/%HOME_PATH%/g, (process.env.PM2_HOME || process.env.HOME));
   script = script.toString().replace(/%NODE_PATH%/g, p.dirname(process.execPath));
   script = script.toString().replace(/%USER%/g, user);
 

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -183,7 +183,7 @@ Satan.launchDaemon = function(cb) {
     cwd        : process.cwd(),
     env        : util._extend({
       'SILENT' : cst.DEBUG ? !cst.DEBUG : true,
-      'HOME'   : process.env.HOME
+      'HOME'   : (process.env.PM2_HOME || process.env.HOME)
     }, process.env),
     stdio      : 'ignore'
   }, function(err, stdout, stderr) {

--- a/lib/scripts/pm2-init-centos.sh
+++ b/lib/scripts/pm2-init-centos.sh
@@ -24,7 +24,7 @@ PM2=%PM2_PATH%
 USER=%USER%
 
 export PATH=$PATH:%NODE_PATH%
-export HOME="%HOME_PATH%"
+export PM2_HOME="%HOME_PATH%"
 
 lockfile="/var/lock/subsys/pm2-init.sh"
 

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -21,7 +21,7 @@ PM2=%PM2_PATH%
 USER=%USER%
 
 export PATH=$PATH:%NODE_PATH%
-export HOME="%HOME_PATH%"
+export PM2_HOME="%HOME_PATH%"
 
 super() {
     sudo -Ei -u $USER PATH=$PATH $*


### PR DESCRIPTION
PM2 won't run as user with no home or read only home folder. Introducing PM2_HOME allow to specify which folder should be used to keep .pm2 things.
