### PR TITLE
Added support for Amazon Linux startup script

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -41,6 +41,7 @@ var default_conf = {
   CENTOS_STARTUP_SCRIPT : '../lib/scripts/pm2-init-centos.sh',
   UBUNTU_STARTUP_SCRIPT : '../lib/scripts/pm2-init.sh',
   SYSTEMD_STARTUP_SCRIPT: '../lib/scripts/pm2.service',
+  AMAZON_STARTUP_SCRIPT: '../lib/scripts/pm2-init-amazon.sh',
 
   SUCCESS_EXIT       : 0,
   ERROR_EXIT         : 1,

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -225,6 +225,8 @@ CLI.startup = function(platform) {
   }
   else if (platform == 'centos' || platform == 'redhat')
     script = fs.readFileSync(path.join(__dirname, cst.CENTOS_STARTUP_SCRIPT));
+  else if (platform == 'amazon')
+    script = fs.readFileSync(path.join(__dirname, cst.AMAZON_STARTUP_SCRIPT));
   else
     script = fs.readFileSync(path.join(__dirname, cst.UBUNTU_STARTUP_SCRIPT));
 
@@ -260,7 +262,7 @@ CLI.startup = function(platform) {
 
     console.log(cst.PREFIX_MSG + '-systemd- Using the command %s', cmd);
   }
-  else if (platform == 'centos' || platform == 'redhat') {
+  else if (platform == 'centos' || platform == 'redhat' || platform == 'amazon') {
     cmd = 'chmod +x ' + INIT_SCRIPT + '; chkconfig --add ' + p.basename(INIT_SCRIPT);
     console.log(cst.PREFIX_MSG + '-centos- Using the command %s', cmd);
     fs.openSync('/var/lock/subsys/pm2-init.sh', 'w');
@@ -274,7 +276,7 @@ CLI.startup = function(platform) {
   exec(cmd, function(err, stdo, stde) {
     if (err) {
       console.error(err);
-      console.log('----- Are you sure you use the right platform command line option ? centos / redhat, ubuntu or systemd?');
+      console.log('----- Are you sure you use the right platform command line option ? centos / redhat, amazon, ubuntu or systemd?');
       exitCli(cst.ERROR_EXIT);
     }
     console.log(stdo);

--- a/lib/scripts/pm2-init-amazon.sh
+++ b/lib/scripts/pm2-init-amazon.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# pm2 Process manager for NodeJS
+#
+# chkconfig: 345 80 20
+#
+# description: PM2 next gen process manager for Node.js
+# processname: pm2
+#
+### BEGIN INIT INFO
+# Provides:          pm2
+# Required-Start: $local_fs $remote_fs
+# Required-Stop: $local_fs $remote_fs
+# Should-Start: $network
+# Should-Stop: $network
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description: PM2 init script
+# Description: PM2 is the next gen process manager for Node.js
+### END INIT INFO
+
+NAME=pm2
+PM2=%PM2_PATH%
+USER=%USER%
+
+export PATH=$PATH:%NODE_PATH%
+export HOME="%HOME_PATH%"
+
+lockfile="/var/lock/subsys/pm2-init.sh"
+
+start() {
+    echo "Starting $NAME"
+    $PM2 resurrect
+    retval=$?
+    [ $retval -eq 0 ] && touch $lockfile
+}
+
+stop() {
+    echo "Stopping $NAME"
+    $PM2 dump
+    $PM2 delete all
+    $PM2 kill
+    rm -f $lockfile
+}
+
+restart() {
+    echo "Restarting $NAME"
+    stop
+    start
+}
+
+reload() {
+    echo "Reloading $NAME"
+    $PM2 reload all
+}
+
+status() {
+    echo "Status for $NAME:"
+    $PM2 list
+    RETVAL=$?
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+    restart)
+        restart
+        ;;
+    reload)
+        reload
+        ;;
+    *)
+        echo "Usage: {start|stop|status|restart|reload}"
+        exit 1
+        ;;
+esac
+exit $RETVAL


### PR DESCRIPTION
Script is based heavily off of the CentOS/Redhat script, with the calls to super removed.

I'm not quite sure how to test this apart from firing up an EC2 instance with the Amazon Linux AMI, but if you have any suggestions, I'm more than willing to implement them.

For what it's worth, my installation process looks like this (starting from fresh Amazon Linux):

```
# Update
sudo yum update
sudo yum groupinstall "Development Tools"

# Set up Node.js
curl https://raw.github.com/creationix/nvm/master/install.sh | sh
source ~/.bash_profile
nvm install 0.10 && nvm use 0.10 && nvm alias default 0.10
```
