### PR TITLE
fix crash in `pm2 desc id`

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -8,6 +8,7 @@ var util      = require('util');
 var cronJob   = require('cron').CronJob;
 
 var cst       = require('../constants.js');
+var extItps   = require('./interpreter.json');
 var p         = path;
 
 /**
@@ -35,6 +36,15 @@ Common.resolveAppPaths = function(app, cwd, outputter) {
   app.env = app.env || {};
   app.env.pm_cwd = cwd;
 
+  if (!app.exec_interpreter) {
+    if (extItps[path.extname(app.script)]) {
+      app.exec_interpreter = extItps[path.extname(app.script)];
+      app.exec_mode = 'fork_mode';
+    } else {
+      app.exec_interpreter = 'node';
+    }
+  };
+
   if (!('exec_mode' in app)) app['exec_mode'] = 'cluster_mode';
 
   app["pm_exec_path"] = path.resolve(cwd, app.script);
@@ -43,7 +53,6 @@ Common.resolveAppPaths = function(app, cwd, outputter) {
   if (!app["name"]) {
     app["name"] = p.basename(app["pm_exec_path"]);
   }
-
 
   if (fs.existsSync(app.pm_exec_path) == false) {
     return new Error('script not found : ' + app.pm_exec_path);


### PR DESCRIPTION
When process start from json file and not declared the 'exec_interpreter' property, `pm2 desc id` command will crash in line [L52](https://github.com/Unitech/pm2/blob/master/lib/CliUx.js#L52).

So I modified the `common.resolveAppPaths` method to add the default 'exec_interpreter' property. It will also set a ext based interpreter property, as the same of `CLI.startFile`.
