### PR TITLE
Stripping environment variables from the HttpInterface

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -33,6 +33,7 @@ var default_conf = {
 
   DEBUG              : process.env.PM2_DEBUG || false,
   WEB_INTERFACE      : parseInt(process.env.PM2_API_PORT)  || 9615,
+  WEB_STRIP_ENV_VARS : process.env.PM2_WEB_STRIP_ENV_VARS || true,
   MODIFY_REQUIRE     : process.env.PM2_MODIFY_REQUIRE || false,
   PREFIX_MSG         : '\x1B[32mPM2 \x1B[39m',
   PREFIX_MSG_ERR     : '\x1B[31mPM2 [ERROR] \x1B[39m',

--- a/lib/HttpInterface.js
+++ b/lib/HttpInterface.js
@@ -48,6 +48,17 @@ http.createServer(function (req, res) {
         processes: data_proc
       };
 
+      if (cst.WEB_STRIP_ENV_VARS === true) {
+        for (var i = data.processes.length - 1; i >= 0; i--) {
+          var process = data.processes[i];
+
+          // Strip important environment variables
+          if (typeof process.pm2_env === 'undefined' && typeof process.pm2_env.env === 'undefined') return;
+
+          delete process.pm2_env.env;
+        }
+      }
+
       res.statusCode = 200;
       res.write(JSON.stringify(data));
       return res.end();
@@ -58,7 +69,7 @@ http.createServer(function (req, res) {
     res.statusCode = 404;
     res.write(JSON.stringify({err : '404'}));
     return res.end();
-  };
+  }
 }).listen(cst.WEB_INTERFACE);
 
 


### PR DESCRIPTION
This gives the user to expose or strip environment variables from the HttpInterface.
By default, they are not exposed due to security reasons.
