### PR TITLE
Adding configuration option max_restarts to allow min_update to work properly

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -88,14 +88,18 @@ function handleExit(clu, exit_code) {
    * Avoid infinite reloop if an error is present
    */
   // If the process has been created less than 15seconds ago
-  if ((Date.now() - clu.pm2_env.created_at) < 15000) {
-    // And if the process has an uptime less than a second
-    if ((Date.now() - clu.pm2_env.pm_uptime) < (clu.pm2_env.min_uptime || 1000)) {
+
+  // And if the process has an uptime less than a second
+  var min_uptime = (clu.pm2_env.min_uptime || 1000);
+  var max_restarts = (clu.pm2_env.max_restarts || 15);
+
+  if ((Date.now() - clu.pm2_env.created_at) < (min_uptime * max_restarts)) {
+    if ((Date.now() - clu.pm2_env.pm_uptime) < min_uptime) {
       // Increment unstable restart
       clu.pm2_env.unstable_restarts += 1;
     }
 
-    if (clu.pm2_env.unstable_restarts >= 15) {
+    if (clu.pm2_env.unstable_restarts >= max_restarts) {
       // Too many unstable restart in less than 15 seconds
       // Set the process as 'ERRORED'
       // And stop to restart it


### PR DESCRIPTION
Hi! We needed min_update to be a little larger, around 2 seconds, but this didn't play well with pm2 as there was a hard dependency on not failing under 15 seconds. So I fixed that by adding a new configuration property "max_restarts", and modified the code to what I thought was decent. I did add some code in README.md in master only to realize that the one in development was much shorter. And there was no documentation of the JSON format that I could find. How do you want to do with that? Should I make a PR from my master -> master?
