### PR TITLE
provides small grammar fixes for CLI, God/ActionMethods

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -860,7 +860,7 @@ CLI.describeProcess = function(pm2_id) {
     });
 
     if (found === false) {
-      printError('%d id doesn\'t exists', pm2_id);
+      printError('%d id doesn\'t exist', pm2_id);
       return exitCli(cst.ERROR_EXIT);
     }
     return exitCli(cst.SUCCESS_EXIT);

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -24,7 +24,7 @@ var pidusage      = require('pidusage');
  * Description
  * @method exports
  * @param {} God
- * @return 
+ * @return
  */
 module.exports = function(God) {
 
@@ -33,7 +33,7 @@ module.exports = function(God) {
    * @method getMonitorData
    * @param {} env
    * @param {} cb
-   * @return 
+   * @return
    */
   God.getMonitorData = function(env, cb) {
     var processes = God.getFormatedProcesses();
@@ -81,7 +81,7 @@ module.exports = function(God) {
    * @method getSystemData
    * @param {} env
    * @param {} cb
-   * @return 
+   * @return
    */
   God.getSystemData = function(env, cb) {
     God.getMonitorData(env, function(err, processes) {
@@ -118,7 +118,7 @@ module.exports = function(God) {
    * @method stopAll
    * @param {} env
    * @param {} cb
-   * @return 
+   * @return
    */
   God.stopAll = function(env, cb) {
     var processes = God.getFormatedProcesses();
@@ -316,7 +316,7 @@ module.exports = function(God) {
    * @method stopProcessName
    * @param {} name
    * @param {} cb
-   * @return 
+   * @return
    */
   God.stopProcessName = function(name, cb) {
     var processes = God.findByName(name);
@@ -362,7 +362,7 @@ module.exports = function(God) {
    * @method sendSignalToProcessName
    * @param {} opts
    * @param {} cb
-   * @return 
+   * @return
    */
   God.sendSignalToProcessName = function(opts, cb) {
     var processes = God.findByName(opts.process_name);
@@ -393,7 +393,7 @@ module.exports = function(God) {
    * @method deleteProcessName
    * @param {} name
    * @param {} cb
-   * @return 
+   * @return
    */
   God.deleteProcessName = function(name, cb) {
     var processes = God.findByName(name);
@@ -419,7 +419,7 @@ module.exports = function(God) {
    * @method deleteAll
    * @param {} opts
    * @param {} cb
-   * @return 
+   * @return
    */
   God.deleteAll = function(opts, cb) {
     var processes = God.getFormatedProcesses();
@@ -447,7 +447,7 @@ module.exports = function(God) {
    * @method killMe
    * @param {} env
    * @param {} cb
-   * @return 
+   * @return
    */
   God.killMe = function(env, cb) {
     God.deleteAll({}, function(err, processes) {
@@ -470,7 +470,7 @@ module.exports = function(God) {
    * @param {} method
    * @param {} value
    * @param {} fn
-   * @return 
+   * @return
    */
   God.stopWatch = function(method, value, fn) {
     var env;
@@ -504,7 +504,7 @@ module.exports = function(God) {
    * @param {} method
    * @param {} value
    * @param {} fn
-   * @return 
+   * @return
    */
   God.restartWatch = function(method, value, fn) {
     var env;
@@ -572,7 +572,7 @@ module.exports = function(God) {
           action_exist = true;
       });
       if (action_exist == false) {
-        return cb(God.logAndGenerateError('Action doesnt exists ' + opts.msg + ' for ' + proc.pm2_env.name), {});
+        return cb(God.logAndGenerateError('Action doesn\'t exist ' + opts.msg + ' for ' + proc.pm2_env.name), {});
       }
 
       if (proc.pm2_env.status == cst.ONLINE_STATUS) {


### PR DESCRIPTION
This pull request contains minor grammar fixes for the singular cases of "id doesn't exist" and "Action doesn't exist."  Additionally, trailing spaces have been cleaned up.
