### PR TITLE
Add force-reload to upstart script

### DIFF
--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -71,8 +71,11 @@ case "$1" in
     reload)
         reload
         ;;
+    force-reload)
+        reload
+        ;;
     *)
-        echo "Usage: {start|stop|status|restart|reload}"
+        echo "Usage: {start|stop|status|restart|reload|force-reload}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
The LSB core spec specifies that all init scripts shall have a force-reload action that ensures that the configuration file is reloaded. This is often implemented by restarting the service. But as pm2 supports reloading configuration files without restarting, force-reload can just point to reload.

Fixes #468
