### PR TITLE
Startup refractor

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -400,26 +400,25 @@ CLI.startup = function(platform, opts, cb) {
 
   if (platform == 'systemd') {
     cmd = [
-      'sudo -Ei -u ' + user + ' pm2 dump', //We need an empty dump so that the first resurrect works correctly
+      'pm2 dump', //We need an empty dump so that the first resurrect works correctly
       'pm2 kill',
       'systemctl daemon-reload',
       'systemctl enable pm2',
       'systemctl start pm2'
     ].join(' && ');
-
-    printOut(cst.PREFIX_MSG + '-systemd- Using the command %s', cmd);
   }
   else if (platform == 'centos' || platform == 'redhat' || platform == 'amazon') {
     cmd = 'chmod +x ' + INIT_SCRIPT + '; chkconfig --add ' + p.basename(INIT_SCRIPT);
-    printOut(cst.PREFIX_MSG + '-centos- Using the command %s', cmd);
     fs.openSync('/var/lock/subsys/pm2-init.sh', 'w');
     printOut('/var/lock/subsys/pm2-init.sh lockfile has been added');
   }
   else {
-    //                                  without beeing root, update-rc.d is not found
-    cmd = 'chmod +x ' + INIT_SCRIPT + ' && sudo update-rc.d ' + p.basename(INIT_SCRIPT) + ' defaults';
-    printOut(cst.PREFIX_MSG + '-ubuntu- Using the command %s', cmd);
+    cmd = 'chmod +x ' + INIT_SCRIPT + ' && update-rc.d ' + p.basename(INIT_SCRIPT) + ' defaults';
   }
+
+  cmd = 'su -c "' + cmd + '"';
+
+  printOut(cst.PREFIX_MSG + '-'+platform+'- Using the command %s', cmd);
 
   exec(cmd, function(err, stdo, stde) {
     if (err) {

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -24,7 +24,7 @@ export PATH=$PATH:%NODE_PATH%
 export PM2_HOME="%HOME_PATH%"
 
 super() {
-    sudo -i -u $USER PATH=$PATH $*
+    su - $USER -c "PATH=$PATH; $*"
 }
 
 start() {


### PR DESCRIPTION
- replaced all instances of `sudo` by native `su`
- startup scripts are called with `su -c "cmd"`
- improved code (less repetitions)
- user is added to the init script but isn't the one that fix permission and put the upstart script

Should fix #408 #524
