### PR TITLE
remove padding from descriptions

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -121,7 +121,7 @@ function failOnUnknown(fn) {
 //
 commander.command('start <file|json|stdin>')
   .option('--watch', 'Watch folder for changes')
-  .description('                start and daemonize an app')
+  .description('start and daemonize an app')
   .action(function(cmd) {
     if (cmd == "-") {
       process.stdin.resume();
@@ -137,13 +137,13 @@ commander.command('start <file|json|stdin>')
   });
 
 commander.command('deploy <file|environment>')
-  .description('                deploy your json')
+  .description('deploy your json')
   .action(function(cmd) {
     CLI.deploy(cmd, commander);
   });
 
 commander.command('startOrRestart <json>')
-  .description('                start or restart JSON file')
+  .description('start or restart JSON file')
   .action(function(file) {
     CLI._jsonStartOrAction('restart', file, commander);
   });
@@ -153,7 +153,7 @@ commander.command('startOrRestart <json>')
 //
 commander.command('stop <id|name|all|json|stdin>')
   .option('--watch', 'Stop watching folder for changes')
-  .description('          stop a process (to start it again, do pm2 restart <app>)')
+  .description('stop a process (to start it again, do pm2 restart <app>)')
   .action(function(param) {
     CLI.stop(param);
   });
@@ -163,7 +163,7 @@ commander.command('stop <id|name|all|json|stdin>')
 //
 commander.command('restart <id|name|all|json|stdin>')
   .option('--watch', 'Toggle watching folder for changes')
-  .description('       restart a process')
+  .description('restart a process')
   .action(function(param) {
     CLI.restart(param);
   });
@@ -172,7 +172,7 @@ commander.command('restart <id|name|all|json|stdin>')
 // Reload process(es)
 //
 commander.command('reload <name|all>')
-  .description('                 reload processes (note that its for app using HTTP/HTTPS)')
+  .description('reload processes (note that its for app using HTTP/HTTPS)')
   .action(function(pm2_id) {
     CLI.reload(pm2_id);
   });
@@ -181,13 +181,13 @@ commander.command('reload <name|all>')
 // Reload process(es)
 //
 commander.command('gracefulReload <name|all>')
-.description('              gracefully reload a process. Send a "shutdown" message to close all connections.')
+.description('gracefully reload a process. Send a "shutdown" message to close all connections.')
   .action(function(pm2_id) {
     CLI.gracefulReload(pm2_id);
   });
 
 // commander.command('gracefulStop <name|all>')
-// .description('              gracefully reload a process. Send a "shutdown" message to close all connections.')
+// .description('gracefully reload a process. Send a "shutdown" message to close all connections.')
 //   .action(function(pm2_id) {
 //     CLI.gracefulStop(pm2_id);
 //   });
@@ -196,7 +196,7 @@ commander.command('gracefulReload <name|all>')
 // Stop and delete a process by name from database
 //
 commander.command('delete <name|id|script|all|json|stdin>')
-  .description(' stop and delete a process from pm2 process list')
+  .description('stop and delete a process from pm2 process list')
   .action(function(name) {
     if (name == "-") {
       process.stdin.resume();
@@ -213,7 +213,7 @@ commander.command('delete <name|id|script|all|json|stdin>')
 // Send system signal to process
 //
 commander.command('sendSignal <signal> <pm2_id|name>')
-  .description('      send a system signal to the target process')
+  .description('send a system signal to the target process')
   .action(function(signal, pm2_id) {
     if (isNaN(parseInt(pm2_id))) {
       console.log(cst.PREFIX_MSG + 'Sending signal to process name ' + pm2_id);
@@ -228,13 +228,13 @@ commander.command('sendSignal <signal> <pm2_id|name>')
 // Stop and delete a process by name from database
 //
 commander.command('ping')
-  .description('                 ping pm2 daemon - if not up it will launch it')
+  .description('ping pm2 daemon - if not up it will launch it')
   .action(function() {
           CLI.ping();
           });
 
 commander.command('updatePM2')
-  .description('                 updatePM2 after a npm update')
+  .description('updatePM2 after a npm update')
   .action(function() {
           CLI.updatePM2()
           });


### PR DESCRIPTION
With this and https://github.com/visionmedia/commander.js/pull/237 patch --help output would look like this:

```
$ ./pm2

  Usage: pm2 [cmd] app

  Commands:

    start [options] <file|json|stdin>                  start and daemonize an app
    deploy <file|environment>                          deploy your json
    startOrRestart <json>                              start or restart JSON file
    stop [options] <id|name|all|json|stdin>            stop a process (to start it again, do pm2 restart <app>)
    restart [options] <id|name|all|json|stdin>         restart a process
    reload <name|all>                                  reload processes (note that its for app using HTTP/HTTPS)
    gracefulReload <name|all>                          gracefully reload a process. Send a "shutdown" message to close all connections.
    delete <name|id|script|all|json|stdin>             stop and delete a process from pm2 process list
    sendSignal <signal> <pm2_id|name>                  send a system signal to the target process
    ping                                               ping pm2 daemon - if not up it will launch it
    updatePM2                                          updatePM2 after a npm update
    interact [secret_key] [public_key] [machine_name]  launch agent to interact with Keymetrics
    killInteract                                       stop agent
    infoInteract                                       get information about agent
    web                                                launch an health API on port 9615
    dump                                               dump all processes for resurrecting them later
    save                                               (alias) dump all processes for resurrecting them later
    resurrect                                          resurrect previously dumped processes
    startup <platform>                                 auto resurect process at startup. [platform] = ubuntu, centos, gentoo or systemd
    generate                                           generate an ecosystem.json configuration file
    ecosystem                                          generate an ecosystem.json configuration file
    describe <id>                                      describe all parameters of a process id
    desc <id>                                          describe all parameters of a process id
    list                                               list all processes
    ls                                                 (alias) list all processes
    l                                                  (alias) list all processes
    status                                             (alias) list all processes
    jlist                                              list all processes in JSON format
    prettylist                                         print json in a prettified JSON
    monit                                              launch termcaps monitoring
    m                                                  (alias) launch termcaps monitoring
    flush                                              flush logs
    reloadLogs                                         reload all logs
    logs [id|name]                                     stream logs file. Default stream all logs
    ilogs                                              advanced interface to display logs
    kill                                               kill daemon
    *                                                  undefined

  Options:

    -h, --help                           output usage information
    -V, --version                        output the version number
    -v --version                         get version
    -s --silent                          hide all messages
    -m --mini-list                       display a compacted list without formatting
    -f --force                           force actions
    -n --name <name>                     set a <name> for script
    -i --instances <number>              launch [number] instances (for networked app)(load balanced)
    -o --output <path>                   specify out log file
    -e --error <path>                    specify error log file
    -p --pid <pid>                       specify pid file
    --env <environment_name>             specify environment to get specific env variables (for JSON declaration)
    -x --execute-command                 execute a program using fork system
    -u --user <username>                 define user when generating startup script
    -c --cron <cron_pattern>             restart a running process based on a cron pattern
    -w --write                           write configuration in local folder
    --interpreter <interpreter>          the interpreter pm2 should use for executing app (bash, python...)
    --log-date-format <momentjs format>  add custom prefix timestamp to logs
    --no-daemon                          run pm2 daemon in the foreground if it doesn't exist already
    --merge-logs                         merge logs from different instances but keep error and out separated
    --watch                              watch application folder for changes
    --node-args <node_args>              space delimited arguments to pass to node in cluster mode - e.g. --node-args="--debug=7001 --trace-deprecation"
    --run-as-user <run_as_user>          The user or uid to run a managed process as
    --run-as-group <run_as_group>        The group or gid to run a managed process as
    --no-color                           skip colors

  Basic Examples:

    Start an app using all CPUs available + set a name :
    $ pm2 start app.js -i max --name "api"

    Restart the previous app launched, by name :
    $ pm2 restart api

    Stop the app :
    $ pm2 stop api

    Restart the app that is stopped :
    $ pm2 restart api

    Remove the app from the process list :
    $ pm2 delete api

    Kill daemon pm2 :
    $ pm2 kill

    Update pm2 :
    $ npm install pm2@latest -g ; pm2 updatePM2

    More examples in https://github.com/Unitech/pm2#usagefeatures

  Deployment help:

    $ pm2 deploy help

```
