### PR TITLE
Avoid using console.log in Satan.launchDaemon[child.once('message')] function

### DIFF
--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -282,7 +282,6 @@ Satan.launchDaemon = function(cb) {
 
   child.once('message', function(msg) {
     process.emit('satan:daemon:ready');
-    console.log(msg);
     return setTimeout(function() {cb(null, child)}, 150);
   });
 };


### PR DESCRIPTION
It breaks pm2 jlist if daemon is not started. In short if we use `pm2 jlist` when daemon is not started, the output is like the following:

```
{ online: true, success: true, pid: 9067, pm2_version: '0.9.6' }
[]
```

that is not a valid JSON - `jlist` command is therefore unusable programmatically.
