### PR TITLE
Removed coffe-script register from process container

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -6,8 +6,6 @@ var fs     = require('fs');
 var p      = require('path');
 var cst    = require('../constants');
 
-require('coffee-script/register');
-
 /**
  * Main entrance to wrap the desired code
  */
@@ -81,6 +79,10 @@ function exec(script, outFile, errFile) {
   process.chdir(process.env.PWD || p.dirname(script));
 
   var stderr, stdout;
+  
+  if(p.extname(script) == '.coffee') {
+    require('coffee-script/register');
+  }
 
   process.on('message', function (msg) {
     if (msg.type === 'log:reload') {

--- a/test/bash/misc.sh
+++ b/test/bash/misc.sh
@@ -77,3 +77,12 @@ cat outmerge-0.log > /dev/null
 ispec 'file outmerge-0.log should not exist'
 
 rm outmerge*
+
+########### coffee cluster test
+$pm2 kill
+
+$pm2 start echo.coffee
+
+should 'process should not have been restarted' 'restart_time: 0' 1
+should 'process should be online' "status: 'online'" 1
+


### PR DESCRIPTION
This is taking a lot of ram and is not useful if you don't run any
coffescript. It is required when the extension name is `.coffee`

We could add an `--interpreter coffee` but atm `cluster` mode does not take any  (https://github.com/Unitech/pm2/blob/master/lib/CLI.js#L87) and it is still running with node, not with coffee so it could mislead users.
