### PR TITLE
show script args in describe output table

### DIFF
--- a/lib/CliUx.js
+++ b/lib/CliUx.js
@@ -53,6 +53,7 @@ UX.describeTable = function(process) {
     { 'name': pm2_env.name },
     { 'id' : pm2_env.pm_id },
     { 'path' : pm2_env.pm_exec_path },
+    { 'args' : pm2_env.args ? JSON.parse(pm2_env.args).join(' ') : '' },
     { 'exec cwd' : pm2_env.pm_cwd },
     { 'error log path' : pm2_env.pm_err_log_path },
     { 'out log path' : pm2_env.pm_out_log_path },


### PR DESCRIPTION
It would be nice to show script args in `pm2 desc` table.
