### PR TITLE
fix typo(resurect -> resurrect)

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -289,7 +289,7 @@ commander.command('save')
   }));
 
 //
-// Resurect
+// Resurrect
 //
 commander.command('resurrect')
   .description('resurrect previously dumped processes')
@@ -302,7 +302,7 @@ commander.command('resurrect')
 // Set pm2 to startup
 //
 commander.command('startup <platform>')
-  .description('auto resurect process at startup. [platform] = ubuntu, centos, gentoo or systemd')
+  .description('auto resurrect process at startup. [platform] = ubuntu, centos, gentoo or systemd')
   .action(function(platform) {
     CLI.startup(platform, commander);
   });

--- a/test/bash/cli.sh
+++ b/test/bash/cli.sh
@@ -204,7 +204,7 @@ success "Processes sucessfully restarted with a specific name"
 $pm2 kill
 
 $pm2 resurrect
-spec "Should resurect all apps"
+spec "Should resurrect all apps"
 
 sleep 0.5
 OUT=`$pm2 prettylist | grep -o "restart_time" | wc -l`

--- a/test/bash/fork.sh
+++ b/test/bash/fork.sh
@@ -27,7 +27,7 @@ $pm2 kill
 $pm2 start echo.coffee -x --interpreter coffee
 should 'should has forked app' 'fork_mode' 1
 
-### Dump resurect should be ok
+### Dump resurrect should be ok
 $pm2 dump
 
 $pm2 kill


### PR DESCRIPTION
fixed resurect typo for comment and **pm2 help**'s `startup <platform>` command usage.
