### PR TITLE
Ensure open file handles are closed again.

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -457,12 +457,12 @@ CLI.startup = function(platform, opts, cb) {
   }
   else if (platform == 'centos' || platform == 'redhat' || platform == 'amazon') {
     cmd = 'chmod +x ' + INIT_SCRIPT + '; chkconfig --add ' + p.basename(INIT_SCRIPT);
-    fs.openSync('/var/lock/subsys/pm2-init.sh', 'w');
+    fs.closeSync(fs.openSync('/var/lock/subsys/pm2-init.sh', 'w'));
     printOut('/var/lock/subsys/pm2-init.sh lockfile has been added');
   }
   else if (platform == 'gentoo') {
     cmd = 'chmod +x ' + INIT_SCRIPT + '; rc-update add ' + p.basename(INIT_SCRIPT) + ' default';
-    fs.openSync('/var/lock/subsys/pm2-init.sh', 'w');
+    fs.closeSync(fs.openSync('/var/lock/subsys/pm2-init.sh', 'w'));
     printOut('/var/lock/subsys/pm2-init.sh lockfile has been added');
   }
   else {
@@ -1222,7 +1222,7 @@ CLI.jlist = function(debug) {
  */
 CLI.flush = function(cb) {
   printOut(cst.PREFIX_MSG + 'Flushing ' + cst.PM2_LOG_FILE_PATH);
-  fs.openSync(cst.PM2_LOG_FILE_PATH, 'w');
+  fs.closeSync(fs.openSync(cst.PM2_LOG_FILE_PATH, 'w'));
 
   Satan.executeRemote('getMonitorData', {}, function(err, list) {
     if (err) {
@@ -1234,8 +1234,8 @@ CLI.flush = function(cb) {
       printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
       printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
 
-      fs.openSync(l.pm2_env.pm_out_log_path, 'w');
-      fs.openSync(l.pm2_env.pm_err_log_path, 'w');
+      fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
+      fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
     });
     printOut(cst.PREFIX_MSG + 'Logs flushed');
     return cb ? cb(null, list) : exitCli(cst.SUCCESS_EXIT);


### PR DESCRIPTION
This fixes a "Error: EMFILE, too many open files" error we've been seeing.
