### PR TITLE
Avoid restart of killed process on "pm2 stop id"

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -76,8 +76,7 @@ God.handleExit = function handleExit(clu, exit_code) {
 
   if (proc.pm2_env.axm_actions) proc.pm2_env.axm_actions = [];
 
-  if (proc.pm2_env.status != cst.ERRORED_STATUS &&
-      proc.pm2_env.status != cst.STOPPING_STATUS)
+  if (proc.pm2_env.status != cst.ERRORED_STATUS)
     proc.pm2_env.status = cst.STOPPED_STATUS;
 
   try {

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -218,8 +218,8 @@ module.exports = function(God) {
       /**
        * Process to stop on fork mode
        */
-      God.killProcess(proc.process.pid, function() {
-        proc.pm2_env.status = cst.STOPPED_STATUS;
+      God.killProcess(proc.process.pid, function(err , killed) {
+        proc.pm2_env.status = killed ? cst.STOPPED_STATUS : cst.STOPPING_STATUS;
         return cb(null, God.getFormatedProcesses());
       });
       return false;


### PR DESCRIPTION
If a process for some reason delays to exit, pm2 restarts the process.

This is partial fix commit, fixing only the stop procedure. 
If you want to restart the process, the process is going to spawn two times in a row. One from the restart procedure and one from the monitor procedure.

Example testcase:
try to restart the process and then pm2 list
```javascript
process.on('SIGTERM', function() {
  console.log('Got SIGTERM signal.');
  exit();
});
process.on('SIGINT', function() {
  console.log('SIGINT signal');
  exit();
});
function exit(){
	console.log("Delay exit in 2 secs");
	setTimeout(function(){
		process.exit();
	}, 2000);
}
(function wait () {
    setTimeout(wait, 1000);
})();
console.log("Now you can exit.");
```