### PR TITLE
Update chokidar to 0.9.0 to avoid install failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   "dependencies": {
     "async"               : "~0.9.0",
     "chalk"               : "~0.5.1",
-    "chokidar"            : "0.8.4",
+    "chokidar"            : "0.9.0",
     "cli-table"           : "0.3.0",
     "coffee-script"       : "1.8.0",
     "colors"              : "0.6.2",


### PR DESCRIPTION
Older version of chokidar (0.8.4) depends an outdated version of fsevent, which would [fails to install](https://github.com/pipobscure/fsevents/pull/26) on Node beta (v0.11+).

The latest version of chokidar rectifies this problem. And `npm test` runs fine with the new chokidar.
