### PR TITLE
Remove the init script lockfile on Gentoo

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -413,8 +413,6 @@ CLI.startup = function(platform, opts, cb) {
   }
   else if (platform == 'gentoo') {
     cmd = 'chmod +x ' + INIT_SCRIPT + '; rc-update add ' + p.basename(INIT_SCRIPT) + ' default';
-    fs.openSync('/var/lock/subsys/pm2-init.sh', 'w');
-    printOut('/var/lock/subsys/pm2-init.sh lockfile has been added');
   }
   else {
     cmd = 'chmod +x ' + INIT_SCRIPT + ' && update-rc.d ' + p.basename(INIT_SCRIPT) + ' defaults';


### PR DESCRIPTION
Gentoo does not use the same likefiles as redhat and centos.
Fixes #770
