### PR TITLE
Added variable to define how much time pm2 will wait for listening event in cluster mode

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -440,7 +440,7 @@ Then use the command:
 $ pm2 gracefulReload [all|name]
 ```
 
-When PM2 starts a new process to replace an old one, it will wait for the new process to begin listening to a connection before sending the shutdown message to the old one.  If a script does not need to listen to a connection, it can manually tell PM2 that the process has started up by calling `process.send('online')`.
+When PM2 starts a new process to replace an old one, it will wait for the new process to begin listening to a connection or a timeout before sending the shutdown message to the old one. You can define the timeout value with the `PM2_GRACEFUL_LISTEN_TIMEOUT` environamente variable. I f a script does not need to listen to a connection, it can manually tell PM2 that the process has started up by calling `process.send('online')`.
 
 <a name="a8"/>
 ## Startup script

--- a/constants.js
+++ b/constants.js
@@ -63,6 +63,7 @@ var default_conf = {
   INTERACTOR_RPC_PORT      : p.join(DEFAULT_FILE_PATH, 'interactor.sock'),
 
   GRACEFUL_TIMEOUT         : parseInt(process.env.PM2_GRACEFUL_TIMEOUT) || 8000,
+  GRACEFUL_LISTEN_TIMEOUT  : parseInt(process.env.PM2_GRACEFUL_LISTEN_TIMEOUT) || 4000,
 
   DEBUG                    : process.env.PM2_DEBUG || false,
   WEB_INTERFACE            : parseInt(process.env.PM2_API_PORT)  || 9615,

--- a/lib/God/Reload.js
+++ b/lib/God/Reload.js
@@ -59,7 +59,7 @@ function softReload(God, id, cb) {
     timer_3 = setTimeout(function() {
       new_worker.removeListener('listening', onListen);
       softCleanDeleteProcess();
-    }, 4000);
+    }, cst.GRACEFUL_LISTEN_TIMEOUT);
 
     // Remove old worker properly
     var softCleanDeleteProcess = function () {


### PR DESCRIPTION
Added environment variable PM2_GRACEFUL_LISTEN_TIMEOUT to define how much time pm2 will wait for the child process to send a listening event in cluster mode before sending the shutdown message to the old process.

The timeout was hardcoded with 4000ms. Just added the environment variable and changed the documentation
