### PR TITLE
[fix #292] specify how to run non-JS applications in app.json

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -620,6 +620,26 @@ Note that if you execute `pm2 start node-app-2` again, it will spawn an addition
 }]
 ```
 
+### Non-JS intepreters
+
+To run a non-JS interpreter you must set `exec_mode` to `fork_mode` and `exec_interpreter` to your interpreter of choice. For example:
+
+```json
+{
+  "apps" : [{
+    "name"       : "bash-worker",
+    "script"     : "./a-bash-script",
+    "exec_interpreter": "bash",
+    "exec_mode"  : "fork_mode"
+  }, {
+    "name"       : "ruby-worker",
+    "script"     : "./some-ruby-script",
+    "exec_interpreter": "ruby",
+    "exec_mode"  : "fork_mode"
+  }]
+}
+```
+
 <a name="deployment"/>
 # Deployment
 


### PR DESCRIPTION
this wasn't specified, and confused lots of people.
