### PR TITLE
Use current directory for .pm2 when no $HOME defined

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -12,7 +12,7 @@ var PM2_ROOT_PATH = '';
 if (process.env.PM2_HOME)
   PM2_ROOT_PATH = process.env.PM2_HOME;
 else
-  PM2_ROOT_PATH = p.resolve(process.env.HOME || process.env.HOMEPATH, '.pm2');
+  PM2_ROOT_PATH = p.resolve(process.env.HOME || process.env.HOMEPATH || '', '.pm2');
 
 /**
  * Constants variables used by PM2


### PR DESCRIPTION
```bash
$ pm2 -v
0.12.1
$ unset HOME
$ pm2 -v    

path.js:313
        throw new TypeError('Arguments to path.resolve must be strings');
              ^
TypeError: Arguments to path.resolve must be strings
    at Object.exports.resolve (path.js:313:15)
    at Object.<anonymous> (/home/vgiersch/bin/node-v0.10.26-linux-x64/lib/node_modules/pm2/constants.js:15:21)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/vgiersch/bin/node-v0.10.26-linux-x64/lib/node_modules/pm2/lib/Satan.js:18:14)
    at Module._compile (module.js:456:26)
```