### PR TITLE
fix: match more complex arguments

### DIFF
--- a/lib/tools/Config.js
+++ b/lib/tools/Config.js
@@ -174,7 +174,7 @@ Config._valid = function(key, value, sch){
   if(scht.length > 1 && type != scht[0] && type == '[object String]'){
     if(scht[0] == '[object Array]') {
       // unfortunately, js does not support lookahead RegExp (/(?<!\\)\s+/) now (until next ver).
-      value = value.split(/(\S+\=['"].+['"])|(['"].+['"])|\s/)
+      value = value.split(/([\w\-]+\="[^"]*")|([\w\-]+\='[^']*')|"([^"]*)"|'([^']*)'|\s/)
         .filter(function(v){
           return v && v.trim();
         }).map(function(v){


### PR DESCRIPTION
Like 

``` javascript
{
  "args": "port=3000 title=\"first title\" name='initial name' --verbose \"debug enabled\""
}
```

should be divided into

``` javascript
[ 'port=3000',
  'title=first title',
  'name=initial name',
  '--verbose',
  'debug enabled' ]
```
