### PR TITLE
Update chokidar fix #870

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   "dependencies": {
     "async"               : "~0.9.0",
     "chalk"               : "~0.5.1",
-    "chokidar"            : "~0.10.1",
+    "chokidar"            : "~0.12.0",
     "cli-table"           : "0.3.0",
     "coffee-script"       : "1.8.0",
     "colors"              : "0.6.2",


### PR DESCRIPTION
> `options.followSymlinks` (default: true). When false, only the symlinks themselves will be watched for changes instead of following the link references and bubbling events through the link's path.

Default is true, dunno if we need a configuration for this.

:warning:  A lots of commit has been made too this new chokidar version.
