### PR TITLE
doc: adds the --interpreter flag to the coffee-script example

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -1225,7 +1225,7 @@ And with JSON declaration:
 ## CoffeeScript
 
 ```bash
-$ pm2 start my_app.coffee
+$ pm2 start server.coffee --interpreter coffee
 ```
 
 That's all!


### PR DESCRIPTION
Coffee-script requires the --interpreter coffee flag

https://github.com/Unitech/PM2/issues/488#issuecomment-68023008
