### PR TITLE
Never start a process that already has a PID

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -311,6 +311,7 @@ God.handleExit = function handleExit(clu, exit_code) {
       // Set the process as 'ERRORED'
       // And stop to restart it
       proc.pm2_env.status = cst.ERRORED_STATUS;
+      proc.process.pid = 0;
 
       console.log('Script %s had too many unstable restarts (%d). Stopped. %j',
                   proc.pm2_env.pm_exec_path,

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -160,8 +160,13 @@ module.exports = function(God) {
     if (!(id in God.clusters_db))
       return cb(God.logAndGenerateError(id + ' id unknown'), {});
 
-    if (God.clusters_db[id].pm2_env.status == cst.ONLINE_STATUS)
+    var proc = God.clusters_db[id];
+    if (proc.pm2_env.status == cst.ONLINE_STATUS)
       return cb(God.logAndGenerateError('process already online'), {});
+
+    if (proc.process && proc.process.pid)
+      return cb(God.logAndGenerateError('process pid exists'), {});
+
     return God.executeApp(God.clusters_db[id].pm2_env, cb);
   };
 

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -68,7 +68,7 @@ module.exports = function(God) {
 
     if (proc.pm2_env.vizion_running === true)
     {
-      console.log('Vizion is already running for proc id: %d, skipping this round', proc_id);
+      console.log('Vizion is already running for proc id: %d, skipping this round', proc.pm2_env.pm_id);
       return cb();
     }
 


### PR DESCRIPTION
This fixes an issue where 2 simultaneous `restart`'s on a `fork_mode` process results in 2 running processes.