### PR TITLE
Fixing spelling mistake in cli message developped -> developed

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -1633,7 +1633,7 @@ function checkExecMode(conf) {
   if (/^cluster(_mode)?$/i.test(conf.exec_mode) &&
       process.version.match(/0.10/) &&
       !process.env.TRAVIS) {
-    warn('You should not use the cluster_mode (-i) in production, it\'s still a beta feature. A front HTTP load balancer or interaction with NGINX will be developped in the future.');
+    warn('You should not use the cluster_mode (-i) in production, it\'s still a beta feature. A front HTTP load balancer or interaction with NGINX will be developed in the future.');
   }
 }
 


### PR DESCRIPTION
Fixing spelling mistake in cli message developped -> developed