### PR TITLE
Windoze

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -17,6 +17,8 @@ else if (process.env.HOME || process.env.HOMEPATH)
 else
   PM2_ROOT_PATH = p.resolve('/etc', '.pm2');
 
+debug("PM2_ROOT_PATH: " + PM2_ROOT_PATH)
+
 /**
  * Constants variables used by PM2
  */

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -412,7 +412,11 @@ module.exports = function(God) {
       Satan.pub_socket.close(function() {
         console.log('PUB socket closed');
 
-        process.kill(parseInt(opts.pid), 'SIGQUIT');
+        var kill_signal = 'SIGQUIT';
+        if (process.platform === 'win32' || process.platform === 'win64') {
+          kill_signal = 'SIGTERM';
+        }
+        process.kill(parseInt(opts.pid), kill_signal);
 
         setTimeout(function() {
           process.exit(cst.SUCCESS_EXIT);

--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -323,6 +323,11 @@ Satan.launchDaemon = function launchDaemon(cb) {
     node_args = node_args.concat(process.env.PM2_NODE_OPTIONS.split(' '));
   node_args.push(SatanJS);
 
+  debug("env.PM2_HOME: " + process.env.PM2_HOME);
+  debug("env.HOME: " + process.env.HOME);
+  debug("env.HOMEPATH: " + process.env.HOMEPATH)
+  debug("resolved HOME: " + (process.env.PM2_HOME || process.env.HOME || process.env.HOMEPATH) );
+
   var child = require('child_process').spawn('node', node_args, {
     detached   : true,
     cwd        : process.cwd(),


### PR DESCRIPTION
Windows doesn't support SIGQUIT, so running "pm2 kill" doesn't clean up Satan. Using SIGTERM instead.
Added some additional debugging for Windows related issues when it comes to finding PM2_HOME as well.