### PR TITLE
darwin startup script fix on yosemite

### DIFF
--- a/lib/scripts/io.keymetrics.PM2.plist
+++ b/lib/scripts/io.keymetrics.PM2.plist
@@ -8,8 +8,9 @@
 	<string>%USER%</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>%PM2_PATH%</string>
-		<string>resurrect</string>
+		<string>/bin/sh</string>
+		<string>-c</string>
+		<string>%PM2_PATH% resurrect</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
Hi,
I've been trying darwin startup script on Yosemite, and in error log it always gave me this message:
env: node: No such file or directory

Can't say why as nothing seems to be missing in plist file. I also tried to create the launch plist by myself and results where similar. 

Anyway by running the command with bash, everything works fine. I couldn't test it in older OS though.