### PR TITLE
Fixed improper '--instances' parsing

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -1648,6 +1648,10 @@ function checkDeprecates(conf){
   }
   if (typeof(conf.instances) === 'string')
     conf.instances = parseInt(conf.instances);
+    
+  // Sanity check, default to number of cores if value can't be parsed
+  if (isNaN(conf.instances))
+    conf.instances = 0;
 }
 
 /**


### PR DESCRIPTION
In #993 I described what happens if you leave out the argument for `--instances`

I've added a simple fix to check if conf.instances is NaN to avoid this