### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Compatible with [io.js](https://github.com/iojs/io.js) and [Node.js](https://git
 Compatible with CoffeeScript.
 Works on Linux (stable) & MacOSx (stable) & Windows (bêta).
 
-[![NPM version](https://badge.fury.io/js/pm2.png)](http://badge.fury.io/js/pm2) [![Build Status](https://api.travis-ci.org/Unitech/PM2.png?branch=master)](https://travis-ci.org/Unitech/PM2) [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/Unitech/PM2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![pm2 API Documentation](https://www.omniref.com/js/npm/pm2.png)](https://www.omniref.com/js/npm/pm2)
+[![NPM version](https://badge.fury.io/js/pm2.png)](http://badge.fury.io/js/pm2) [![Build Status](https://api.travis-ci.org/Unitech/PM2.png?branch=master)](https://travis-ci.org/Unitech/PM2) [![Inline docs](http://inch-ci.org/github/unitech/pm2.svg?branch=master)](http://inch-ci.org/github/unitech/pm2) [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/Unitech/PM2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![pm2 API Documentation](https://www.omniref.com/js/npm/pm2.png)](https://www.omniref.com/js/npm/pm2)
 
 [![NPM](https://nodei.co/npm/pm2.png?downloads=true&downloadRank=true)](https://nodei.co/npm/pm2/)
 


### PR DESCRIPTION
Hi Alex,

as requested this PR would add a badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/Unitech/pm2.svg)](http://inch-ci.org/github/Unitech/pm2) Your status page is http://inch-ci.org/github/Unitech/pm2

 As you might have guessed, this is still in a "beta" or "early-adopter" state. Some of the evaluations seem a bit user-unfriendly like `Event#module.exports#module.exports.God.notify.event.manually.process.at.God.notifyByProcessId`. :dizzy_face: 

I hope you are willing to give this a chance nonetheless, as it is not about showing that a project is perfectly documented, but to show people that there are inline docs and to encourage them to dive into your code.

What do you think?
