### PR TITLE
Attempt to fix #1009

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -432,7 +432,7 @@ God.finalizeProcedure = function finalizeProcedure(proc) {
 
     proc.pm2_env.vizion_running = false;
 
-    if (!err) {
+    if (!err && current_path) {
       proc.pm2_env.versioning = meta;
       proc.pm2_env.versioning.repo_path = current_path;
       God.notify('online', proc);
@@ -442,7 +442,7 @@ God.finalizeProcedure = function finalizeProcedure(proc) {
       God.notify('online', proc);
     }
     else {
-      current_path = path.dirname(current_path);
+      current_path = path.dirname(current_path || proc.pm2_env.pm_exec_path);
       proc.pm2_env.vizion_running = true;
       vizion.analyze({folder : current_path}, recur_path);
     }


### PR DESCRIPTION
`current_path` is sometimes undefined after the vizion analyze