### PR TITLE
stringify env values to handle non-string variables from json file

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -242,7 +242,7 @@ CLI.actionFromJson = function(action, file, jsonVia, cb) {
 
   async.eachLimit(appConf, cst.CONCURRENT_ACTIONS, function(proc, next1) {
     var name = '';
-    var new_env = proc.env ? proc.env : {};
+    var new_env = mergeEnvironmentVariables(proc);
 
     if (!proc.name)
       name = p.basename(proc.script);
@@ -1521,6 +1521,16 @@ function mergeEnvironmentVariables(app, envName, deployConf) {
 
     app.env = finalEnv;
   }
+
+  // JSON.stringify non-string entries
+  var stringifiedEnv = {};
+  for (var key in app.env) {
+    if (app.env.hasOwnProperty(key)) {
+      var value = app.env[key];
+      stringifiedEnv[key] = (typeof value === 'string') ? value : JSON.stringify(value);
+    }
+  }
+  app.env = stringifiedEnv;
 
   return app.env;
 }

--- a/test/bash/env-refresh.sh
+++ b/test/bash/env-refresh.sh
@@ -42,7 +42,7 @@ $pm2 restart env-refreshed.json
 >out-env.log
 
 sleep 0.5
-grep "HEYYYY" out-env.log &> /dev/null
+grep '{"HEYYYY":true}' out-env.log &> /dev/null
 spec "should contain refreshed env variable via json"
 
 

--- a/test/fixtures/env-refreshed.json
+++ b/test/fixtures/env-refreshed.json
@@ -5,6 +5,6 @@
   "merge_logs" : true,
   "env": {
     "NODE_ENV": "production",
-    "TEST_VARIABLE": "HEYYYY"
+    "TEST_VARIABLE": { "HEYYYY": true }
   }
 }]


### PR DESCRIPTION
This allows the env option to handle simple values and objects, like:

```json
"env": {
  "LIMIT": 10,
  "CONFIG": {
    "enabled": true
  }
}
```

Which will be passed on as `LIMIT='10'` & `CONFIG='{"enabled":true}'`.