### PR TITLE
Use NODE_PATH before system paths

### DIFF
--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -20,7 +20,7 @@ NAME=pm2
 PM2=%PM2_PATH%
 USER=%USER%
 
-export PATH=$PATH:%NODE_PATH%
+export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 super() {


### PR DESCRIPTION
Fix System Path being used before NODE_PATH, to override system installed versions of node. #1121