### PR TITLE
Use NODE_PATH before system paths

### DIFF
--- a/lib/scripts/pm2
+++ b/lib/scripts/pm2
@@ -5,7 +5,7 @@ extra_started_commands="reload"
 PM2=%PM2_PATH%
 USER=%USER%
 
-export PATH=$PATH:%NODE_PATH%
+export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 super() {

--- a/lib/scripts/pm2-init-amazon.sh
+++ b/lib/scripts/pm2-init-amazon.sh
@@ -23,7 +23,7 @@ NAME=pm2
 PM2=%PM2_PATH%
 USER=%USER%
 
-export PATH=$PATH:%NODE_PATH%
+export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 lockfile="/var/lock/subsys/pm2-init.sh"

--- a/lib/scripts/pm2-init-centos.sh
+++ b/lib/scripts/pm2-init-centos.sh
@@ -23,7 +23,7 @@ NAME=pm2
 PM2=%PM2_PATH%
 USER=%USER%
 
-export PATH=$PATH:%NODE_PATH%
+export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 lockfile="/var/lock/subsys/pm2-init.sh"

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -20,7 +20,7 @@ NAME=pm2
 PM2=%PM2_PATH%
 USER=%USER%
 
-export PATH=$PATH:%NODE_PATH%
+export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 super() {


### PR DESCRIPTION
Fix System Path being used before NODE_PATH, to override system installed versions of node(/iojs). #1121 