### PR TITLE
Proxy Support

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -9,6 +9,7 @@ var debug                = require('debug')('pm2:monit');
 var util                 = require('util');
 var chalk                = require('chalk');
 var exec                 = require('child_process').exec;
+var globalTunnel         = require('global-tunnel');
 
 var p                    = path;
 
@@ -31,6 +32,10 @@ var Deploy               = require('pm2-deploy');
 var exitCli    = Common.exitCli;
 var printError = Common.printError;
 var printOut   = Common.printOut;
+/**
+ * Proxy support
+ */
+globalTunnel.initialize();
 
 CLI.pm2Init = function() {
   if (!fs.existsSync(cst.PM2_ROOT_PATH)) {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,8 @@
     "moment"              : "2.9.0",
     "nssocket"            : "0.5.3",
     "pidusage"            : "0.1.1",
-
+    "global-tunnel"       : "~1.2.0",
+    
     "pmx"                 : "latest",
     "vizion"              : "latest",
 


### PR DESCRIPTION
Hello, 

I included proxy support for PM2 using `global-tunnel`.
It works with the env variable `http_proxy`

I tested with the command `pm2 interact` and worked fine!

Cheers,
