### PR TITLE
use bash shell by default in pm2 ubuntu init script

### DIFF
--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -19,13 +19,24 @@
 NAME=pm2
 PM2=%PM2_PATH%
 USER=%USER%
-SHELL=/bin/bash
 
 export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
+get_user_shell() {
+    local shell=$(getent passwd $1 | cut -d: -f7)
+
+    if [[ $shell == *"/sbin/nologin" ]] || [[ $shell == "/bin/false" ]];
+    then
+      shell="/bin/bash"
+    fi
+
+    echo "$shell"
+}
+
 super() {
-    su - $USER -s $SHELL -c "PATH=$PATH; $*"
+    local shell=$(get_user_shell $USER)
+    su - $USER -s $shell -c "PATH=$PATH; $*"
 }
 
 start() {

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -19,12 +19,13 @@
 NAME=pm2
 PM2=%PM2_PATH%
 USER=%USER%
+SHELL=/bin/bash
 
 export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 super() {
-    su - $USER -c "PATH=$PATH; $*"
+    su - $USER -s $SHELL -c "PATH=$PATH; $*"
 }
 
 start() {

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -24,7 +24,7 @@ export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 get_user_shell() {
-    local shell=$(getent passwd $1 | cut -d: -f7)
+    local shell=$(getent passwd ${1:-`whoami`} | cut -d: -f7)
 
     if [[ $shell == *"/sbin/nologin" ]] || [[ $shell == "/bin/false" ]];
     then


### PR DESCRIPTION
Hey,
In a recent attempt to use PM2 on an Ubuntu instance (on an AWS EC2 instance), using the startup script failed for me. After some probing around i identified the problem was that when using pm2 with a system user for startup, i.e invoking:
```
        $ pm2 startup ubuntu -u www-data
```
The resulting init script would fail to execute correctly due to www-data having no login by default (by default on Ubuntu its shell is set to /usr/sbin/nologin). 

changing the super() command to invoke su with -s /bin/bash seems to work and I cannot see any scenario where this would be a problem in this context.

Attached the PR for this issue, happy to iterate on this with you guys

thanks,
Adam