### PR TITLE
adds opts.user to the init script name

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -439,6 +439,10 @@ CLI.startup = function(platform, opts, cb) {
 
   var user = opts.user || 'root';
 
+  if (user != 'root'){
+    scriptFile = scriptFile.replace(/pm2/i, '$&-'+user);
+  }
+  
   script = script.replace(/%PM2_PATH%/g, process.mainModule.filename)
     .replace(/%HOME_PATH%/g, cst.PM2_ROOT_PATH)
     .replace(/%NODE_PATH%/g, platform != 'darwin' ? p.dirname(process.execPath) : process.env.PATH)


### PR DESCRIPTION
This very simple PR adds the user name, from the `-u --user` switch to the name of the init script generated by `pm2 startup …`.

This should contribute a possible solution to issues  #889 #1193
