### PR TITLE
Set PM2_HOME on the user session starting pm2.

### DIFF
--- a/lib/scripts/pm2
+++ b/lib/scripts/pm2
@@ -9,7 +9,7 @@ export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
 super() {
-    su - $USER -c "PATH=$PATH; $*"
+    su - $USER -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
 }
 
 depend() {

--- a/lib/scripts/pm2-init-amazon.sh
+++ b/lib/scripts/pm2-init-amazon.sh
@@ -28,18 +28,22 @@ export PM2_HOME="%HOME_PATH%"
 
 lockfile="/var/lock/subsys/pm2-init.sh"
 
+super() {
+    su - $USER -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
+}
+
 start() {
     echo "Starting $NAME"
-    $PM2 resurrect
+    super $PM2 resurrect
     retval=$?
     [ $retval -eq 0 ] && touch $lockfile
 }
 
 stop() {
     echo "Stopping $NAME"
-    $PM2 dump
-    $PM2 delete all
-    $PM2 kill
+    super $PM2 dump
+    super $PM2 delete all
+    super $PM2 kill
     rm -f $lockfile
 }
 
@@ -51,12 +55,12 @@ restart() {
 
 reload() {
     echo "Reloading $NAME"
-    $PM2 reload all
+    super $PM2 reload all
 }
 
 status() {
     echo "Status for $NAME:"
-    $PM2 list
+    super $PM2 list
     RETVAL=$?
 }
 

--- a/lib/scripts/pm2-init-centos.sh
+++ b/lib/scripts/pm2-init-centos.sh
@@ -29,7 +29,7 @@ export PM2_HOME="%HOME_PATH%"
 lockfile="/var/lock/subsys/pm2-init.sh"
 
 super() {
-    su - $USER -c "PATH=$PATH; $*"
+    su - $USER -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
 }
 
 start() {

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -36,7 +36,7 @@ get_user_shell() {
 
 super() {
     local shell=$(get_user_shell $USER)
-    su - $USER -s $shell -c "PATH=$PATH; $*"
+    su - $USER -s $shell -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
 }
 
 start() {


### PR DESCRIPTION
This is a quick fix to update the majority of the init scripts to set the PM2_HOME environmental variable to whatever it's defined on the session of the user running pm2.

Not having this caused $PM2_HOME to default to $HOME/.pm2 which might not be consistent and break the startup ability - since dump was created in a different location.

It also ports the run as user ability from the centos init script to the amazon init script.