### PR TITLE
Use USER constant in pm2-init-amazon.sh

### DIFF
--- a/lib/scripts/pm2-init-amazon.sh
+++ b/lib/scripts/pm2-init-amazon.sh
@@ -28,18 +28,22 @@ export PM2_HOME="%HOME_PATH%"
 
 lockfile="/var/lock/subsys/pm2-init.sh"
 
+super() {
+    su - $USER -c "PATH=$PATH; $*"
+}
+
 start() {
     echo "Starting $NAME"
-    $PM2 resurrect
+    super $PM2 resurrect
     retval=$?
     [ $retval -eq 0 ] && touch $lockfile
 }
 
 stop() {
     echo "Stopping $NAME"
-    $PM2 dump
-    $PM2 delete all
-    $PM2 kill
+    super $PM2 dump
+    super $PM2 delete all
+    super $PM2 kill
     rm -f $lockfile
 }
 
@@ -51,12 +55,12 @@ restart() {
 
 reload() {
     echo "Reloading $NAME"
-    $PM2 reload all
+    super $PM2 reload all
 }
 
 status() {
     echo "Status for $NAME:"
-    $PM2 list
+    super $PM2 list
     RETVAL=$?
 }
 


### PR DESCRIPTION
These are similar issues.

- https://github.com/Unitech/PM2/issues/1100
- https://github.com/Unitech/PM2/pull/1156

In [this](https://github.com/Unitech/PM2/commit/602677f5e8ab3e29c3e3eb8ed729c3a37763d437) commit, 'super()' is omitted Intentionally. As a result, -u option of pm2 command cannot be recognized. I think we should use 'super()'.

