### PR TITLE
Support JS in addition to JSON and JSON5 config files

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -6,7 +6,9 @@ var fs                   = require('fs');
 var path                 = require('path');
 var async                = require('async');
 var debug                = require('debug')('pm2:monit');
+var semver               = require('semver');
 var util                 = require('util');
+var vm                   = require('vm');
 var chalk                = require('chalk');
 var exec                 = require('child_process').exec;
 
@@ -214,7 +216,7 @@ CLI.deploy = function(file, commands, cb) {
     env = args[1];
 
   try {
-    var json_conf = json5.parse(fs.readFileSync(file));
+    var json_conf = parseConfig(fs.readFileSync(file), file);
   } catch (e) {
     printError(e);
     return cb ? cb(e) : exitCli(cst.ERROR_EXIT);
@@ -844,7 +846,7 @@ CLI.remote = function(command, opts, cb) {
 /**
  * Start or restart|reload|gracefulReload a JSON configuration file
  * @param {string} action    restart|reload
- * @param {string} json_conf json file path
+ * @param {string} json_conf JS file path
  * @param {string} opts      option like environment type and co
  * @callback cb optional
  * @param cb
@@ -857,7 +859,7 @@ CLI._jsonStartOrAction = function(action, json_conf, opts, cb) {
     return cb ? cb(e) : exitCli(cst.ERROR_EXIT);
   }
 
-  var appConf = json5.parse(data), deployConf = null;
+  var appConf = parseConfig(data, json_conf), deployConf = null;
   // v2 JSON declaration
   if (appConf.deploy) deployConf = appConf.deploy;
   if (appConf.apps) appConf = appConf.apps;
@@ -1432,7 +1434,7 @@ CLI.monit = function(cb) {
  * @return
  */
 CLI.streamLogs = function(id, lines, raw) {
-  
+
   if (typeof lines !== 'number')
     lines = 20;
   Satan.executeRemote('getMonitorData', {}, function(err, list) {
@@ -2102,6 +2104,27 @@ function prepareInterpreter(conf){
     conf.exec_interpreter = betterInterpreter || 'none';
   }
 
+}
+
+/**
+ * Parses a config file like ecosystem.json. Supported formats: JS, JSON, JSON5.
+ * @param {string} confString  contents of the config file
+ * @param {string} filename    path to the config file
+ * @return {Object} config object
+ */
+function parseConfig(confString, filename) {
+  var code = '(' + confString + ')';
+  var sandbox = {};
+  if (semver.satisfies(process.version, '>= 0.12.0')) {
+    return vm.runInNewContext(code, sandbox, {
+      filename: path.resolve(filename),
+      displayErrors: false,
+      timeout: 1000,
+    });
+  } else {
+    // Use the Node 0.10 API
+    return vm.runInNewContext(code, sandbox, filename);
+  }
 }
 
 /**


### PR DESCRIPTION
This adds support for full JS within ecosystem config files using the sandboxing capability of Node's vm module. Since JSON and JSON5 are both subsets of JS and don't access any variables in the JS environment, there is no change to existing config files.

Tested with Node 0.10, Node 0.12, io.js 1.8, and io.js 2.0.

Fix #1296 