### PR TITLE
FreeBSD rc script 

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -702,6 +702,8 @@ var watch_options = {
 }
 ```
 
+When working with NFS devices you'll need to set `polling: true` as stated in [this chokidar issue](https://github.com/paulmillr/chokidar/issues/242).  
+
 ## JS/JSON app declaration
 
 PM2 empowers your process management workflow, by allowing you to fine-tune the behavior, options, environment variables, logs files... of each process you need to manage via JSON/JSON5/JS configuration.

--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -285,7 +285,7 @@ $ pm2 completion >> ~/.bashrc # or ~/.zshrc
 Then source your .bashrc or .zshrc file for current session:
 
 ```bash
-$ pm2 source ~/.bashrc # or ~/.zshrc
+$ source ~/.bashrc # or ~/.zshrc
 ```
 
 You can add pm2 completion to your current session this way:

--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -702,7 +702,7 @@ var watch_options = {
 }
 ```
 
-When working with NFS devices you'll need to set `polling: true` as stated in [this chokidar issue](https://github.com/paulmillr/chokidar/issues/242).  
+When working with NFS devices you'll need to set `usePolling: true` as stated in [this chokidar issue](https://github.com/paulmillr/chokidar/issues/242).  
 
 ## JS/JSON app declaration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Please try following these rules it will make the task easier for you and for us
   - pm2 version `pm2 --version`
   - nodejs version `node --version`
   - operating system
+  - `head -n 50 ~/.pm2/pm2.log` output
 
 #### 3. Provide details about your issue:
   - What are the steps that brought me to the issue?

--- a/constants.js
+++ b/constants.js
@@ -45,6 +45,7 @@ var csts = {
   AMAZON_STARTUP_SCRIPT  : '../lib/scripts/pm2-init-amazon.sh',
   GENTOO_STARTUP_SCRIPT  : '../lib/scripts/pm2',
   DARWIN_STARTUP_SCRIPT  : '../lib/scripts/io.keymetrics.PM2.plist',
+  FREEBSD_STARTUP_SCRIPT : '../lib/scripts/pm2-freebsd.sh',
 
   SUCCESS_EXIT           : 0,
   ERROR_EXIT             : 1,

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -573,9 +573,11 @@ CLI.startup = function(platform, opts, cb) {
     scriptFile = '/etc/systemd/system/pm2.service';
   }else if (platform == 'darwin') {
     scriptFile = path.join(process.env.HOME, 'Library/LaunchAgents/io.keymetrics.PM2.plist');
+  }else if (platform == 'freebsd') {
+    scriptFile = '/etc/rc.d/pm2';
   }
 
-  if(!!~['systemd', 'centos', 'amazon', 'gentoo', 'darwin'].indexOf(platform)){
+  if(!!~['freebsd', 'systemd', 'centos', 'amazon', 'gentoo', 'darwin'].indexOf(platform)){
     script = cst[platform.toUpperCase() + '_STARTUP_SCRIPT'];
   }
 
@@ -625,14 +627,20 @@ CLI.startup = function(platform, opts, cb) {
   case 'gentoo':
     cmd = 'chmod +x ' + scriptFile + '; rc-update add ' + p.basename(scriptFile) + ' default';
     break;
-    default :
+  case 'freebsd':
+    cmd = 'chmod +x ' + scriptFile;
+    break;
+  default :
     cmd = 'chmod +x ' + scriptFile + ' && update-rc.d ' + p.basename(scriptFile) + ' defaults';
     break;
   }
 
-  if (platform != 'darwin') {
+
+  if (platform == 'freebsd') {
+    cmd = 'su root -c "' + cmd + '"';
+  }else if (platform != 'darwin') {
     cmd = 'su -c "' + cmd + '"';
-  }else{
+  }else {
     cmd = 'pm2 dump';
   }
 

--- a/lib/scripts/pm2-freebsd.sh
+++ b/lib/scripts/pm2-freebsd.sh
@@ -9,7 +9,7 @@ load_rc_config $name
  
 : ${pm2_user="%USER%"}
  
-command="/usr/local/bin/${name}"
+command="%PM2_PATH%"
 pidfile="/home/${pm2_user}/.pm2/${name}.pid"
 start_cmd="${name}_start"
 stop_cmd="${name}_stop"

--- a/lib/scripts/pm2-freebsd.sh
+++ b/lib/scripts/pm2-freebsd.sh
@@ -7,7 +7,7 @@ rcvar=${name}_enable
  
 load_rc_config $name
  
-: ${pm2_user="root"}
+: ${pm2_user="%USER%"}
  
 command="/usr/local/bin/${name}"
 pidfile="/home/${pm2_user}/.pm2/${name}.pid"

--- a/lib/scripts/pm2.freebsd
+++ b/lib/scripts/pm2.freebsd
@@ -1,0 +1,60 @@
+#!/bin/sh
+ 
+. /etc/rc.subr
+ 
+name=pm2
+rcvar=${name}_enable
+ 
+load_rc_config $name
+ 
+: ${pm2_user="root"}
+ 
+command="/usr/local/bin/${name}"
+pidfile="/home/${pm2_user}/.pm2/${name}.pid"
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+reload_cmd="${name}_reload"
+status_cmd="${name}_status"
+ 
+extra_commands="reload"
+ 
+super() {
+        su - "${pm2_user}" -c "$*"
+}
+ 
+pm2_start() {
+        unset "${rc_flags}_cmd"
+        if pm2_running; then
+                echo "Pm2 is already running, 'pm2 list' to see running processes"
+        else
+                echo "Starting pm2."
+                super $command resurrect
+        fi
+}
+ 
+pm2_stop() {
+        echo "Stoping ${name}..."
+        super $command dump
+        super $command delete all
+        super $command kill
+}
+ 
+pm2_reload() {
+        echo "Reloading ${name}"
+        super $command reload all
+}
+ 
+pm2_status() {
+        super $command list
+}
+ 
+pm2_running() {
+        process_id=$(pgrep -F ${pidfile})
+        if [ "${process_id}" -gt 0 ]; then
+                return 0
+        else
+                return 1
+        fi
+}
+ 
+run_rc_command "$1"


### PR DESCRIPTION
freeBSD rc.script for starting PM2 at boot. 

file needs go in /etc/rc.d/ and need two lines to be added to /etc/rc.conf

pm2_enable="yes" <-- to enable freeBSD to start pm2 at boot
pm2_user="" <-- user that you want to run pm2