### PR TITLE
Force the su command to use bash

### DIFF
--- a/lib/scripts/pm2-init-centos.sh
+++ b/lib/scripts/pm2-init-centos.sh
@@ -29,7 +29,7 @@ export PM2_HOME="%HOME_PATH%"
 lockfile="/var/lock/subsys/pm2-init.sh"
 
 super() {
-    su - $USER -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
+    su - $USER -s /bin/bash -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
 }
 
 start() {

--- a/lib/scripts/pm2-init.sh
+++ b/lib/scripts/pm2-init.sh
@@ -23,20 +23,8 @@ USER=%USER%
 export PATH=%NODE_PATH%:$PATH
 export PM2_HOME="%HOME_PATH%"
 
-get_user_shell() {
-    local shell=$(getent passwd ${1:-`whoami`} | cut -d: -f7 | sed -e 's/[[:space:]]*$//')
-
-    if [[ $shell == *"/sbin/nologin" ]] || [[ $shell == "/bin/false" ]] || [[ -z "$shell" ]];
-    then
-      shell="/bin/bash"
-    fi
-
-    echo "$shell"
-}
-
 super() {
-    local shell=$(get_user_shell $USER)
-    su - $USER -s $shell -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
+    su - $USER -s /bin/bash -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
 }
 
 start() {


### PR DESCRIPTION
Removing the shell detection because it doesn't really help, if the shell is (t)csh the startup command errors out due to syntax.
Closes #890
