### PR TITLE
Fix for startup creating .pm2 folder owned by root in user folder

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -559,7 +559,7 @@ CLI.startup = function(platform, opts, cb) {
   if (process.getuid() != 0) {
     return exec('whoami', function(err, stdout, stderr) {
       console.error(cst.PREFIX_MSG + 'You have to run this command as root. Execute the following command:\n' +
-                    chalk.grey('      sudo env PATH=$PATH:' + p.dirname(process.execPath) + ' pm2 startup ' + platform + ' -u ' + stdout.trim()));
+                    chalk.grey('      sudo su -c "env PATH=$PATH:' + p.dirname(process.execPath) + ' pm2 startup ' + platform + ' -u ' + stdout.trim() +'"'));
       cb ? cb({msg: 'You have to run this with elevated rights'}) : exitCli(cst.ERROR_EXIT);
     });
   }


### PR DESCRIPTION
Fix for https://github.com/Unitech/PM2/issues/1460

When running "startup" command, the entire .pm2 folder or some content may be created in user's home with root ownership. Fixed by executing pm2 through su.

