### PR TITLE
Change default exec mode to fork in prepareConf

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -112,7 +112,7 @@ Common.prepareAppConf = function(app, cwd, outputter) {
   /**
    * Here we put the default exec mode
    */
-  if (!app.exec_mode && app.instances > 0) {
+  if (!app.exec_mode && app.instances > 1) {
     app.exec_mode = 'cluster_mode';
   } else if (!app.exec_mode) {
     app.exec_mode = 'fork_mode';


### PR DESCRIPTION
Should behave the same as cli (cli should probably use common.prepareConf instead of verifying the conf manually).