### PR TITLE
Add nvm compatibility to PM2 systemd startup

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -615,14 +615,16 @@ CLI.startup = function(platform, opts, cb) {
 
   var cmd;
   var cmdAsUser;
+  var cmdPrefix;
 
   printOut(cst.PREFIX_MSG + 'Making script booting at startup...');
 
   switch (platform) {
   case 'systemd':
+    cmdPrefix = 'env PATH=$PATH:' + p.dirname(process.execPath);
     cmdAsUser = [
-      'pm2 dump', //We need an empty dump so that the first resurrect works correctly
-      'pm2 kill',
+      cmdPrefix + ' pm2 dump', //We need an empty dump so that the first resurrect works correctly
+      cmdPrefix + ' pm2 kill',
     ].join(' && ');
     cmd = [
       'systemctl daemon-reload',

--- a/lib/scripts/pm2.service
+++ b/lib/scripts/pm2.service
@@ -6,12 +6,12 @@ After=network.target remote-fs.target
 Type=forking
 User=%USER%
 
-ExecStart=%PM2_PATH% resurrect
-ExecReload=%PM2_PATH% reload all
+ExecStart=/bin/sh -c 'env PATH=$PATH:%NODE_PATH% pm2 resurrect'
+ExecReload=/bin/sh -c 'env PATH=$PATH:%NODE_PATH% pm2 reload all'
 
-ExecStop=%PM2_PATH% dump
-ExecStop=%PM2_PATH% delete all
-ExecStop=%PM2_PATH% kill
+ExecStop=/bin/sh -c 'env PATH=$PATH:%NODE_PATH% pm2 dump'
+ExecStop=/bin/sh -c 'env PATH=$PATH:%NODE_PATH% pm2 delete all'
+ExecStop=/bin/sh -c 'env PATH=$PATH:%NODE_PATH% pm2 kill'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I was running into some issues when running `pm2 startup systemd` on a system with node installed via nvm.

Initially, the environment is set correctly through `sudo su -c 'env PATH=$PATH:/usr/bin pm2 startup systemd -u xxx'`, but once I ran that command, the script it built:

`su web -c "pm2 dump && pm2 kill" && su root -c "systemctl daemon-reload && systemctl enable pm2 && systemctl start pm2"`

Doesn't run pm2 with a valid path to node. So I added the `env` command to each of the `pm2` calls. That caused the script to execute, but the systemd unit also didn't have the path set, so I had to run each command in a shell so I could add the `env` command.

I may be going about this wrong, and if so I apologize. It does mean I'll have to regenerate the startup script whenever I upgrade my version of node. Still, hopefully this is useful to anyone else trying to do something similar.
