### PR TITLE
Warn pm2 startup users that might use systemd

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -11,6 +11,7 @@ var util                 = require('util');
 var vm                   = require('vm');
 var chalk                = require('chalk');
 var exec                 = require('child_process').exec;
+var ini                  = require('ini');
 
 var p                    = path;
 
@@ -562,6 +563,25 @@ CLI.actionFromJson = function(action, file, jsonVia, cb) {
  * @param {string} platform type (centos|redhat|amazon|gentoo|systemd)
  */
 CLI.startup = function(platform, opts, cb) {
+  if (platform == 'linux' || platform == 'redhat' || platform == 'ubuntu' || platform == 'centos') {
+    try {
+      var osRelease = ini.parse(fs.readFileSync('/etc/os-release', 'utf-8'));
+      var mightUseSystemd = false;
+      switch(osRelease.ID) {
+      case 'ubuntu':
+        mightUseSystemd = osRelease.VERSION_ID >= 15.04;
+        break;
+      case 'centos':
+      case 'rhel':
+        mightUseSystemd = osRelease.VERSION_ID >= 7;
+        break;
+      }
+      if (mightUseSystemd) {
+        console.log(cst.PREFIX_MSG_WARNING + 'Your distribution (%s) uses systemd by default. Unless you\'ve changed this, you should run "pm2 startup systemd" instead.', osRelease.PRETTY_NAME);
+      }
+    } catch (e) { }
+  }
+
   if (process.getuid() != 0) {
     return exec('whoami', function(err, stdout, stderr) {
       console.error(cst.PREFIX_MSG + 'You have to run this command as root. Execute the following command:\n' +

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -564,8 +564,18 @@ CLI.actionFromJson = function(action, file, jsonVia, cb) {
  */
 CLI.startup = function(platform, opts, cb) {
   if (platform == 'linux' || platform == 'redhat' || platform == 'ubuntu' || platform == 'centos') {
+    var osReleaseFile = '/etc/os-release';
+    var osReleaseUsrFile = '/usr/lib/os-release';
+    var osRelease = null;
+    // try pulling the os-release file from the two possible locations
     try {
-      var osRelease = ini.parse(fs.readFileSync('/etc/os-release', 'utf-8'));
+      osRelease = ini.parse(fs.readFileSync(osReleaseFile, 'utf-8'));
+    } catch (e) {
+      try {
+        osRelease = ini.parse(fs.readFileSync(osReleaseUsrFile, 'utf-8'));
+      } catch (e) { }
+    }
+    if (osRelease) {
       var mightUseSystemd = false;
       switch(osRelease.ID) {
       case 'ubuntu':
@@ -579,7 +589,7 @@ CLI.startup = function(platform, opts, cb) {
       if (mightUseSystemd) {
         console.log(cst.PREFIX_MSG_WARNING + 'Your distribution (%s) uses systemd by default. Unless you\'ve changed this, you should run "pm2 startup systemd" instead.', osRelease.PRETTY_NAME);
       }
-    } catch (e) { }
+    }
   }
 
   if (process.getuid() != 0) {

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "cron"                : "1.0.9",
     "debug"               : "2.2.0",
     "eventemitter2"       : "0.4.14",
+    "ini"                 : "1.3.4",
     "moment"              : "2.10.6",
     "nssocket"            : "0.5.3",
     "pidusage"            : "0.1.1",


### PR DESCRIPTION
Currently, users of distributions like Ubuntu 15.04 and CentOS/RHEL 7 have to know that their distribution is running `systemd` in order to set up `pm2 startup` correctly. We can check the version listed in the `/etc/os-releases` file to see if it's likely that a user is on one of these systems. If so, this branch outputs a warning:

```
[PM2][WARN] Your distribution (Ubuntu 15.04) uses systemd by default. Unless you've changed this, you should run "pm2 startup systemd" instead.
```

Builds off work in #1120. Resolves #1319
