### PR TITLE
Require `util` module instead of the deprecated `sys` module.

### DIFF
--- a/lib/Interactor/pm2-interface.js
+++ b/lib/Interactor/pm2-interface.js
@@ -5,7 +5,7 @@
 
 var axon = require('pm2-axon');
 var cst  = require('../../constants.js');
-var sys  = require('sys');
+var util  = require('util');
 var rpc  = require('pm2-axon-rpc');
 var log  = require('debug')('pm2:interface');
 var EventEmitter = require('events').EventEmitter;
@@ -121,4 +121,4 @@ var IPM2 = function(sub_port, rpc_port, bind_host) {
 
 };
 
-sys.inherits(IPM2, EventEmitter);
+util.inherits(IPM2, EventEmitter);


### PR DESCRIPTION
`sys` module was deprecated long ago.

There is an ongoing discussion on removing `sys` module completely in the next major version: https://github.com/nodejs/node/pull/2405.