### PR TITLE
Fix #1578 + test ES6 with nodejs 

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -331,7 +331,6 @@ commander.command('updatePM2')
   .action(function() {
     CLI.updatePM2();
   });
-
 commander.command('update')
   .description('(alias) update in-memory PM2 with local PM2')
   .action(function() {
@@ -347,6 +346,13 @@ commander.command('install <module|git:// url>')
   .action(function(plugin_name) {
     CLI.install(plugin_name);
   });
+
+commander.command('module:update <module|git:// url>')
+  .description('update a module and run it forever')
+  .action(function(plugin_name) {
+    CLI.install(plugin_name);
+  });
+
 
 commander.command('module:generate')
   .description('Generate a sample module in current folder')

--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -44,10 +44,10 @@ module.exports = function ClusterMode(God) {
     if (pm2_env.watch &&
         (util.isArray(pm2_env.watch) || typeof pm2_env.watch == 'string' || pm2_env.watch instanceof String)) {
       watch = [].concat(pm2_env.watch).map(function(dir) {
-          return p.resolve(process.env.PWD, dir);
+          return p.resolve(pm2_env.pm_cwd, dir);
       });
     } else {
-      watch = p.dirname(pm2_env.pm_exec_path);
+      watch = pm2_env.pm_cwd;
     }
 
     log('Watching folder %s', watch);


### PR DESCRIPTION
- Don't exit es6 tests if nodejs is detected
- Fix #1578 by using pm_cwd instead of env.PWD