### PR TITLE
Upating watcher.js to work with windows file systems

### DIFF
--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -44,7 +44,7 @@ module.exports = function ClusterMode(God) {
     if (pm2_env.watch &&
         (util.isArray(pm2_env.watch) || typeof pm2_env.watch == 'string' || pm2_env.watch instanceof String)) {
       watch = [].concat(pm2_env.watch).map(function(dir) {
-          return p.resolve(process.env.PWD, dir);
+          return p.resolve(String(process.env.PWD), String(dir));
       });
     } else {
       watch = p.dirname(pm2_env.pm_exec_path);


### PR DESCRIPTION
On windows file systems not setting the type of the arguments to path.resolve causes an error that breaks Watcher, manually setting the types to string fixes this.