### PR TITLE
Deploy to default environment

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -461,8 +461,12 @@ CLI.deploy = function(file, commands, cb) {
     return cb ? cb(e) : exitCli(cst.ERROR_EXIT);
   }
 
-  if (!env)
-    return deployHelp();
+  if (!env) {
+    if (Object.keys(json_conf.deploy).length == 1) {
+      env = Object.keys(json_conf.deploy)[0];
+    } else
+      return deployHelp();
+  }
 
   if (!json_conf.deploy || !json_conf.deploy[env]) {
     printError('%s environment is not defined in %s file', env, file);


### PR DESCRIPTION
When the user deploys without supplying an argument for environment, if there's only 1 defined environment in the ecosystem.json, deploy to that environment.