### PR TITLE
Be sure to call the callback passed to `pm2.deploy`

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -433,8 +433,10 @@ CLI._startJson = function(cmd, opts, jsonVia, cb) {
  * Deploy command
  */
 CLI.deploy = function(file, commands, cb) {
-  if (file == 'help')
-    return deployHelp();
+  if (file == 'help') {
+    deployHelp();
+    return cb ? cb() : exitCli(cst.SUCCESS_EXIT);
+  }
 
   var args = commands.rawArgs;
   var env;
@@ -461,8 +463,10 @@ CLI.deploy = function(file, commands, cb) {
     return cb ? cb(e) : exitCli(cst.ERROR_EXIT);
   }
 
-  if (!env)
-    return deployHelp();
+  if (!env) {
+    deployHelp();
+    return cb ? cb() : exitCli(cst.SUCCESS_EXIT);
+  }
 
   if (!json_conf.deploy || !json_conf.deploy[env]) {
     printError('%s environment is not defined in %s file', env, file);
@@ -479,7 +483,7 @@ CLI.deploy = function(file, commands, cb) {
       return cb ? cb(err) : exitCli(cst.ERROR_EXIT);
     }
     printOut('--> Success');
-    return exitCli(cst.SUCCESS_EXIT);
+    return cb ? cb(null, data) : exitCli(cst.SUCCESS_EXIT);
   });
 };
 
@@ -2556,5 +2560,4 @@ function deployHelp() {
   console.log('');
   console.log('    More examples in https://github.com/Unitech/pm2');
   console.log('');
-  exitCli(cst.SUCCESS_EXIT);
 }


### PR DESCRIPTION
Some times the callback that is passed to `pm2.deploy` is never called. This means tools that use PM2 cannot know when it has completed deploying the code. This commit makes sure we call the callback before exiting.

Fix #1671