### PR TITLE
Change FreeBSD scritptFile path to /usr/local

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -617,7 +617,7 @@ CLI.startup = function(platform, opts, cb) {
       fs.mkdirSync(path.dirname(scriptFile));
     }
   }else if (platform == 'freebsd') {
-    scriptFile = '/etc/rc.d/pm2';
+    scriptFile = '/usr/local/etc/rc.d/pm2';
   }
 
   if(!!~['freebsd', 'systemd', 'centos', 'amazon', 'gentoo', 'darwin'].indexOf(platform)){


### PR DESCRIPTION
On FreeBSD /etc/rc.d is typically reserved for the base system. Third party scripts, like pm2 should go to /usr/local/etc/rc.d
