### PR TITLE
Allows to install packages from tarball generated with 'npm pack'

### DIFF
--- a/lib/Modularizer.js
+++ b/lib/Modularizer.js
@@ -126,8 +126,8 @@ function installModule(module_name, cb) {
 
       Common.printOut(cst.PREFIX_MSG_MOD + 'Module downloaded');
 
-      if (module_name.match(/^.+\/([^\/]+)\.tgz($|\?)/)) {
-        module_name = module_name.match(/^https?:\/\/.+\/([^\/]+)\.tgz($|\?)/)[1];
+      if (module_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)) {
+        module_name = module_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)[2];
         if (module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)) {
           module_name = module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)[1];
         }

--- a/lib/Modularizer.js
+++ b/lib/Modularizer.js
@@ -126,7 +126,13 @@ function installModule(module_name, cb) {
 
       Common.printOut(cst.PREFIX_MSG_MOD + 'Module downloaded');
 
-      if (module_name.indexOf('/') != -1)
+      if (module_name.match(/^.+\/([^\/]+)\.tgz($|\?)/)) {
+        module_name = module_name.match(/^https?:\/\/.+\/([^\/]+)\.tgz($|\?)/)[1];
+        if (module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)) {
+          module_name = module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)[1];
+        }
+      }
+      else if (module_name.indexOf('/') != -1)
         module_name = module_name.split('/')[1];
 
       //pm2 install module@2.1.0-beta


### PR DESCRIPTION
Hello,

This PR enables PM2 to install packages from tarball (generated with the `npm pack` command), if the tarball is properly named:

    pm2 install myapp.tgz
    pm2 install myapp-1.0.0.tgz
    pm2 install http://example.com/packages/myapp-1.0.0.tgz
