### PR TITLE
Fix broken link for contributors page

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -226,7 +226,7 @@
 
 ## Contributors
 
-[Contributors](http://pm2.keymetrics.io/all-of-fame/)
+[Contributors](http://pm2.keymetrics.io/hall-of-fame/)
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Thanks in advance and we hope that you like PM2!
 
 ## Contributors
 
-[Contributors](http://pm2.keymetrics.io/all-of-fame/)
+[Contributors](http://pm2.keymetrics.io/hall-of-fame/)
 
 ## License
 


### PR DESCRIPTION
There was a mistake in the url for the contributors in both the readme files, this commit fixes that.