### PR TITLE
Watcher to log the path which triggered restart

### DIFF
--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -56,7 +56,7 @@ module.exports = function ClusterMode(God) {
 
       self.restarting = true;
 
-      console.error('Change detected for app name: %s - restarting', pm2_env.name, 'Change triggered by', path);
+      console.error('Change detected for app name: %s - restarting', pm2_env.name, 'Changed path', path);
 
       God.restartProcessName(pm2_env.name, function(err, list) {
         self.restarting = false;

--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -56,7 +56,7 @@ module.exports = function ClusterMode(God) {
 
       self.restarting = true;
 
-      console.error('Change detected for app name: %s - restarting', pm2_env.name);
+      console.error('Change detected for app name: %s - restarting', pm2_env.name, 'Change triggered by', path);
 
       God.restartProcessName(pm2_env.name, function(err, list) {
         self.restarting = false;


### PR DESCRIPTION
Watcher to log the path which triggered restart which greatly improves debugging infinite restart loops.