### PR TITLE
Fixing home directory on windows #1781

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -13,7 +13,7 @@ var PM2_ROOT_PATH = '';
 if (process.env.PM2_HOME)
   PM2_ROOT_PATH = process.env.PM2_HOME;
 else if (process.env.HOME || process.env.HOMEPATH)
-  PM2_ROOT_PATH = p.resolve(process.env.HOME || (process.env.HOMEDRIVE + process.env.HOMEPATH), '.pm2');
+  PM2_ROOT_PATH = p.resolve(process.env.HOMEDRIVE, process.env.HOME || process.env.HOMEPATH, '.pm2');
 else
   PM2_ROOT_PATH = p.resolve('/etc', '.pm2');
 


### PR DESCRIPTION
I got the issue on windows, HOME was relative to drive. `process.env.HOME = "\Users\user"` 
Resolving HOME by HOMEDRIVE will no affect if HOME is absolute, and will fix the issue if HOME is relative