### PR TITLE
Deploy to default environment.

### DIFF
--- a/lib/CLI/Deploy.js
+++ b/lib/CLI/Deploy.js
@@ -83,8 +83,12 @@ DeployModule.deploy = function(file, commands, cb) {
   }
 
   if (!env) {
-    deployHelper();
-    return cb ? cb() : Common.exitCli(cst.SUCCESS_EXIT);
+    if (Object.keys(json_conf.deploy).length == 1) {
+      env = Object.keys(json_conf.deploy)[0];
+    } else {
+      deployHelper();
+      return cb ? cb('Configuration file has more than 1 environment. Needs to specify which one.') : Common.exitCli(cst.SUCCESS_EXIT);
+    }
   }
 
   if (!json_conf.deploy || !json_conf.deploy[env]) {

--- a/test/fixtures/deploy.json
+++ b/test/fixtures/deploy.json
@@ -1,0 +1,33 @@
+{
+  /**
+   * Application configuration section
+   * http://pm2.keymetrics.io/docs/usage/application-declaration/
+   */
+  apps : [
+    {
+      name      : "API",
+      script    : "app.js",
+    }
+  ],
+
+  /**
+   * Deployment section
+   * http://pm2.keymetrics.io/docs/usage/deployment/
+   */
+  deploy : {
+    production : {
+          user: "user",
+          host: "host",
+          repo: "repo",
+          path: "path",
+          ref:  "ref"
+    },
+    development: {
+          user: "user",
+          host: "host",
+          repo: "repo",
+          path: "path",
+          ref:  "ref"
+    }
+  }
+}

--- a/test/pm2_programmatic_tests.sh
+++ b/test/pm2_programmatic_tests.sh
@@ -43,6 +43,8 @@ mocha ./test/programmatic/logs.js
 spec "Logs test"
 mocha ./test/programmatic/watcher.js
 spec "Watcher"
+mocha ./test/programmatic/deploy.js
+spec "Deploy"
 mocha ./test/programmatic/modularizer.mocha.js
 spec "Module system"
 mocha ./test/programmatic/max_memory_limit.js

--- a/test/programmatic/deploy.js
+++ b/test/programmatic/deploy.js
@@ -1,0 +1,17 @@
+var should = require('should')
+var assert = require('better-assert');
+var p = require('path');
+var fs = require('fs')
+var EventEmitter = require('events').EventEmitter
+var pm2  = require('../..');
+
+describe('Deploy', function() {
+  it('should fail because of unspecified environment', function(cb) {
+    path = process.cwd() + '/test/fixtures/deploy.json'
+
+    pm2.deploy(path, {rawArgs: ["deploy", path]}, function(err, data) {
+      err.should.eql("Configuration file has more than 1 environment. Needs to specify which one.")
+      cb();
+    });
+  });
+});


### PR DESCRIPTION
When the user deploys without supplying an argument for environment, if there's only 1 defined environment in the ecosystem.json, deploy to that environment.

This is a followup to #1774.