### PR TITLE
minor fix for TypeError('Arguments to path.join must be strings') on Windows

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -148,7 +148,7 @@ CLI._startScript = function(script, opts, cb) {
    * If -w option, write configuration to configuration.json file
    */
   if (appConf.write) {
-    var dst_path = path.join(process.env.PWD, conf.name + '-pm2.json');
+    var dst_path = path.join(process.env.PWD || process.cwd(), conf.name + '-pm2.json');
     Common.printOut(cst.PREFIX_MSG + 'Writing configuration to', chalk.blue(dst_path));
     // pretty JSON
     try {
@@ -1352,11 +1352,11 @@ CLI.generateSample = function() {
   var f_name = 'ecosystem.json';
 
   try {
-    fs.writeFileSync(path.join(process.env.PWD, f_name), dt);
+    fs.writeFileSync(path.join(process.env.PWD || process.cwd(), f_name), dt);
   } catch (e) {
     console.error(e.stack || e);
   }
-  Common.printOut('File %s generated', path.join(process.env.PWD, f_name));
+  Common.printOut('File %s generated', path.join(process.env.PWD || process.cwd(), f_name));
   Common.exitCli(cst.SUCCESS_EXIT);
 }
 


### PR DESCRIPTION
path.js:233
      throw new TypeError('Arguments to path.join must be strings');
            ^
TypeError: Arguments to path.join must be strings
    at Object.win32.join (path.js:233:13)
    at Object.CLI.generateSample (C:\Develop\temp\dep-test\pm2\lib\CLI.js:1359:45)
    at Command.<anonymous> (C:\Develop\temp\dep-test\pm2\bin\pm2:584:9)
    at Command.listener (C:\Develop\temp\dep-test\pm2\node_modules\commander\index.js:301:8)
    at Command.emit (events.js:110:17)
    at Command.parseArgs (C:\Develop\temp\dep-test\pm2\node_modules\commander\index.js:615:12)
    at Command.parse (C:\Develop\temp\dep-test\pm2\node_modules\commander\index.js:458:21)
    at beginCommandProcessing (C:\Develop\temp\dep-test\pm2\bin\pm2:121:13)
    at C:\Develop\temp\dep-test\pm2\bin\pm2:174:7
    at null._onTimeout (C:\Develop\temp\dep-test\pm2\lib\Satan.js:452:19)