### PR TITLE
fix logging wrong "kill_timeout" into God#processIsDead

### DIFF
--- a/lib/God/Methods.js
+++ b/lib/God/Methods.js
@@ -228,7 +228,7 @@ module.exports = function(God) {
         return cb({type : 'timeout', msg : 'timeout'});
       }
       else {
-        console.log('Process with pid %d still alive after %sms, sending it SIGKILL now...', pid, cst.KILL_TIMEOUT);
+        console.log('Process with pid %d still alive after %sms, sending it SIGKILL now...', pid, kill_timeout);
         try {
           crossPlatformGroupKill(parseInt(pid), 'SIGKILL');
         } catch(e) {


### PR DESCRIPTION
I just experimented and observed that the "real" time allotted for the process shutdown does not match recorded in the log.

in my app.json "kill_timeout" = 300 
```
{
  "name": "app",
  "script": ".",
  "kill_timeout": 300
}
```

but in the log I could see conflicting information:
(each `PM2 Process with pid 10696 still not killed, retrying...` = 100 ms)
```
PM2 Stopping app:app id:0
app-0 SIGINT
PM2 Process with pid 10696 still not killed, retrying...
PM2 Process with pid 10696 still not killed, retrying...
PM2 Process with pid 10696 still alive after 1600ms, sending it SIGKILL now...
```

so, pls accept my oneline fix :)