### PR TITLE
Fix auto-start on boot

### DIFF
--- a/lib/scripts/pm2-freebsd.sh
+++ b/lib/scripts/pm2-freebsd.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# PROVIDE: pm2
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+
 . /etc/rc.subr
 
 name=pm2


### PR DESCRIPTION
Add rcorder dependency on LOGIN to make auto-start on boot work. Without this, PM2 does not start up automatically on boot on a standard FreeBSD 10.2 installation (even if pm2_enable=YES is set in rc.conf).