### PR TITLE
Replace shelljs "ugly hack" with shelljs support for silent console

### DIFF
--- a/lib/Modularizer.js
+++ b/lib/Modularizer.js
@@ -105,9 +105,7 @@ function installModule(module_name, cb) {
       process.stdout.write('.');
     }, 500);
 
-    // Redirecting error output to /dev/null
-    // This is a ugly hack
-    shelljs.exec('npm install ' + module_name + ' --prefix ' + cst.PM2_ROOT_PATH + ' 2> /dev/null', function(code) {
+    shelljs.exec('npm install ' + module_name + ' --prefix ' + cst.PM2_ROOT_PATH, {silent : true}, function(code) {
       clearInterval(inter);
 
       if (code != 0) {


### PR DESCRIPTION
Clean up shelljs npm install code for modules as shelljs supports a silent option

Additionally : pm2 modules are completely broken on Windows (and have been for quite some time) because of the /dev/null dependency.  This fixes https://github.com/Unitech/pm2/issues/1750