### PR TITLE
Allows to update packages from tarball generated with 'npm pack'

### DIFF
--- a/bin/pm2-dev
+++ b/bin/pm2-dev
@@ -15,7 +15,7 @@ var moment    = require('moment');
 var Common    = require('../lib/Common');
 var chalk     = require('chalk');
 
-process.env.PM2_SILENT = true;
+process.env.PM2_SILENT = 'true';
 
 commander.version(pkg.version)
   .option('--raw', 'raw log output')

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -1668,14 +1668,14 @@ CLI.killDaemon = CLI.kill = function(cb) {
     if (!err && semver.lt(data, '1.1.0')) {
       // Disable action command output if upgrading from < 1.1.0 PM2
       // This is in order to avoid duplicated output
-      process.env.PM2_SILENT = true;
+      process.env.PM2_SILENT = 'true';
       console.log(cst.PREFIX_MSG + 'Killing processes...');
     }
 
     CLI.killAllModules(function() {
       CLI._operate('deleteProcessId', 'all', function(err, list) {
         Common.printOut(cst.PREFIX_MSG + 'All processes have been stopped and deleted');
-        process.env.PM2_SILENT = false;
+        process.env.PM2_SILENT = 'false';
 
         InteractorDaemonizer.killDaemon(function(err, data) {
           Satan.killDaemon(function(err, res) {

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -292,7 +292,7 @@ Common.printError = function(msg) {
  * @return
  */
 Common.printOut = function() {
-  if (process.env.PM2_SILENT == true || process.env.PM2_PROGRAMMATIC === 'true') return false;
+  if (process.env.PM2_SILENT === 'true' || process.env.PM2_PROGRAMMATIC === 'true') return false;
   return console.log.apply(console, arguments);
 };
 

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -292,7 +292,7 @@ Common.printError = function(msg) {
  * @return
  */
 Common.printOut = function() {
-  if (process.env.PM2_SILENT || process.env.PM2_PROGRAMMATIC === 'true') return false;
+  if (process.env.PM2_SILENT == true || process.env.PM2_PROGRAMMATIC === 'true') return false;
   return console.log.apply(console, arguments);
 };
 

--- a/lib/Modularizer.js
+++ b/lib/Modularizer.js
@@ -18,6 +18,7 @@ var cst           = require('../constants.js');
 var CLI           = require('./CLI.js');
 var Common        = require('./Common');
 var UX            = require('./CLI/CliUx.js');
+var Utility       = require('./Utility.js');
 
 var MODULE_CONF_PREFIX = 'module-db';
 
@@ -122,11 +123,8 @@ function installModule(module_name, cb) {
 
       Common.printOut(cst.PREFIX_MSG_MOD + 'Module downloaded');
 
-      if (module_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)) {
-        module_name = module_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)[2];
-        if (module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)) {
-          module_name = module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)[1];
-        }
+      if (module_name.match(/\.tgz($|\?)/)) {
+        module_name = Utility.packageNameToModuleName(module_name);
       }
       else if (module_name.indexOf('/') != -1)
         module_name = module_name.split('/')[1];
@@ -264,13 +262,15 @@ Modularizer.launchAll = function(cb) {
 Modularizer.install = function(module_name, cb) {
   Common.printOut(cst.PREFIX_MSG_MOD + 'Installing module ' + module_name);
 
-  if (moduleExist(module_name) === true) {
+  var canonic_module_name = Utility.packageNameToModuleName(module_name);
+
+  if (moduleExist(canonic_module_name) === true) {
     /**
      * Update
      */
     Common.printOut(cst.PREFIX_MSG_MOD + 'Module already installed. Updating.');
 
-    uninstallModule(module_name, function(err) {
+    uninstallModule(canonic_module_name, function(err) {
       if (err) return cb({msg : 'Problem when uninstalling module', err : err});
       return installModule(module_name, cb);
     });

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -177,5 +177,20 @@ var Utility = module.exports = {
              filename.indexOf('.yaml') > -1) {
       return yamljs.parse(confObj.toString());
     }
+  },
+  /**
+   * Returns the module name from a .tgz package name (or the original name if it is not a valid pkg).
+   * @param {string} package_name The package name (e.g. "foo.tgz", "foo-1.0.0.tgz", "folder/foo.tgz")
+   * @return {string} the name
+   */
+  packageNameToModuleName: function(package_name) {
+    if (package_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)) {
+      package_name = package_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)[2];
+      if (package_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)) {
+        package_name = package_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)[1];
+      }
+    }
+    return package_name;
   }
+
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm2",
   "preferGlobal": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "node": ">=0.10"
   },

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "pm2-multimeter"      : "0.1.2",
 
     "shelljs"             : "0.6.0",
-    "yamljs"              : "0.2.6",
+    "yamljs"              : "0.2.7",
     "semver"              : "~5.1.0",
     "mkdirp"              : "0.5.1",
     "source-map-support"  : "0.4.0"


### PR DESCRIPTION
Hello,

I already made a PR some time ago (PR #1713) that allows to install module from .tgz packages (generated with the `npm pack` command). But there is a little issue: when updating a package with the `pm2 install foo.tgz` command, it does not updates the package and it starts a new instance of the already installed package. This PR fixes this issue.

Regards,