### PR TITLE
fix cli for node v6

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -2369,7 +2369,7 @@ function checkDeprecates(conf){
  */
 function prepareAppName(conf){
   if (!conf.name){
-    conf.name = p.basename(conf.script);
+    conf.name = conf.script !== undefined ? p.basename(conf.script) : 'undefined';
     var lastDot = conf.name.lastIndexOf('.');
     if (lastDot > 0){
       conf.name = conf.name.slice(0, lastDot);


### PR DESCRIPTION
When `conf.script` is `undefined`, `p.basename` currently returns `"undefined"` in Node.js v5.x. v6.0.0 throws an exception in this case. I'm not sure what it is expected to be so I reproduced the behavior.
Perhaps it should be the empty string instead ?