### PR TITLE
Patch -  systemd service

### DIFF
--- a/lib/scripts/pm2.service
+++ b/lib/scripts/pm2.service
@@ -6,6 +6,7 @@ After=network.target remote-fs.target
 Type=forking
 User=%USER%
 
+ExecStartPre=%PM2_PATH% kill
 ExecStart=%PM2_PATH% resurrect
 ExecReload=%PM2_PATH% reload all
 


### PR DESCRIPTION
Before we start pm2 service, we need to kill previous pm2 daemon (if exists) or it wont lauch the processes in dump.pm2
