### PR TITLE
Load modules in no-daemon mode

### DIFF
--- a/lib/Satan.js
+++ b/lib/Satan.js
@@ -51,7 +51,9 @@ Satan.start = function(noDaemonMode, cb) {
       if (noDaemonMode) {
         debug('Launching in no daemon mode');
         Satan.remoteWrapper();
-        return Satan.launchRPC(cb);
+        return Satan.launchRPC(function() {
+            require('./Modularizer.js').launchAll(cb);
+        });
       }
 
       Satan.printOut(cst.PREFIX_MSG + 'Spawning PM2 daemon');


### PR DESCRIPTION
I don't know if this is intended behavior or not, but no-daemon mode prevents modules from being loaded.

Some background because I never filed an issue: I'm using PM2 with Windows services, which requires no-daemon mode (otherwise Windows thinks the service has crashed when the CLI process exits). I also want to use pm2-logrotate to keep the disk usage down. I imagine this would also be useful with respect to the discussion in #1562.