### PR TITLE
Do not override app config with opts default values (fix #2366)

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -851,9 +851,9 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
   appConf.forEach(function(app) {
     if (opts.only && opts.only != app.name)
       return false;
-    if (opts.watch && opts.watch === true)
+    if (opts.watch && opts.watch === true && !app.watch)
       app.watch = true;
-    if (opts.ignore_watch)
+    if (opts.ignore_watch && !app.ignore_watch)
       app.ignore_watch = opts.ignore_watch;
     if (opts.instances && typeof(opts.instances) === 'number')
       app.instances = opts.instances;

--- a/lib/API.js
+++ b/lib/API.js
@@ -851,9 +851,9 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
   appConf.forEach(function(app) {
     if (opts.only && opts.only != app.name)
       return false;
-    if (opts.watch && opts.watch === true && !app.watch)
+    if (!app.watch && opts.watch && opts.watch === true)
       app.watch = true;
-    if (opts.ignore_watch && !app.ignore_watch)
+    if (!app.ignore_watch && opts.ignore_watch)
       app.ignore_watch = opts.ignore_watch;
     if (opts.instances && typeof(opts.instances) === 'number')
       app.instances = opts.instances;

--- a/test/bash/pm2-dev.sh
+++ b/test/bash/pm2-dev.sh
@@ -8,14 +8,21 @@ rundev="`type -P node` `pwd`/bin/rundev"
 
 export PM2_HOME=$HOME'/.pm2-dev'
 
-$pm2 flush
+cd $file_path/pm2-dev
 
-$rundev start test/fixtures/child.js --test-mode
-
+# Test with js
+$rundev start app.js --test-mode
 $pm2 ls
 should 'should have started 1 apps' 'online' 1
-# echo "Change bomb" > test/fixtures/change
-# rm test/fixtures/change
-# sleep 2
-# should 'should has restarted process' 'restart_time: 1' 1
+should 'should watch be true' 'watch: true' 1
+$pm2 kill
+
+# Test with json and args
+$rundev start app.json --test-mode
+$pm2 ls
+should 'should have started 1 apps' 'online' 1
+$pm2 prettylist | grep "watch: \[ 'server', 'client' \]"
+spec "Should application have two watch arguments"
+$pm2 prettylist | grep "ignore_watch: \[ 'node_modules', 'client/img' \]"
+spec "Should application have two ignore_watch arguments"
 $pm2 kill

--- a/test/fixtures/pm2-dev/app.js
+++ b/test/fixtures/pm2-dev/app.js
@@ -1,0 +1,16 @@
+var http = require('http');
+
+http.createServer(function(req, res) {
+  res.writeHead(200);
+  res.end('hey');
+}).listen(0);
+
+process.on('message', function(msg) {
+  if (msg == 'shutdown') {
+    console.log('Closing all connections...');
+    setTimeout(function() {
+      console.log('Finished closing connections');
+      process.exit(0);
+    }, 100);
+  }
+});

--- a/test/fixtures/pm2-dev/app.json
+++ b/test/fixtures/pm2-dev/app.json
@@ -1,0 +1,5 @@
+{
+  "script": "app.js",
+  "watch": ["server", "client"],
+  "ignore_watch" : ["node_modules", "client/img"]
+}


### PR DESCRIPTION
Fix pm2-dev issue - #2366 
Do not override the application config with the opts default values.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2366
| License       | MIT