### PR TITLE
chore(): update pm2-deploy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "pidusage": "^1.0.8",
     "pm2-axon": "3.0.2",
     "pm2-axon-rpc": "0.4.5",
-    "pm2-deploy": "^0.3",
+    "pm2-deploy": "^0.3.3",
     "pm2-multimeter": "0.1.2",
     "pmx": "^0.6",
     "semver": "^5.2",


### PR DESCRIPTION
I just installed PM2 on a fresh install of Windows 10. I'm using latest LTS version of node and NPM. 

When I ran `npm i -g pm2`, I had `pm2-deploy@0.3.1` installed which was causing problems when deploying to production servers (similar to this issue: https://github.com/Unitech/pm2-deploy/issues/46). I had to manually go to the `pm2` install location and run `npm i pm2-deploy@latest` to fix this issue. 