### PR TITLE
Added launch modules function to api.

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -203,6 +203,15 @@ API.prototype.disconnect = API.prototype.close = function(cb) {
 };
 
 /**
+ * Launch modules
+ *
+ * @param {Function} cb callback once pm2 has launched modules
+ */
+API.prototype.launchModules = function(cb) {
+  Modularizer.launchAll(this, cb);
+};
+
+/**
  * Enable bus allowing to retrieve various process event
  * like logs, restarts, reloads
  *

--- a/test/programmatic/api.mocha.js
+++ b/test/programmatic/api.mocha.js
@@ -269,4 +269,37 @@ describe('API checks', function() {
     });
   });
 
+  describe('Launch modules', function() {
+    var Modularizer = require('../../lib/API/Modules/Modularizer');
+    var module = 'pm2-server-monit';
+
+    after(function(done) {
+      Modularizer.uninstall(PM2, module, done);
+    });
+
+    it('Should start up modules', function(done) {
+      this.timeout(5000);
+      PM2.connect(true, function(err) {
+        should(err).be.null();
+
+        Modularizer.install(PM2, module, function() {
+          PM2.stop(module, function() {
+            should(err).be.null();
+
+            PM2.launchModules(function(err) {
+              should(err).be.null();
+
+              PM2.list(function(err, list) {
+                should(err).be.null();
+                should(list[0].name).eql(module);
+                should(list[0].pm2_env.status).eql('online');
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Hi, I added this function to start up modules programatically, because using API.connect with no daemon set to true eventually results in the modules not being launched at [line 134 of API.js](https://github.com/Unitech/pm2/blob/development/lib/API.js#L136)
```javascript
if (meta.new_pm2_instance == false)
  return cb(err, meta);
```

Cheers!

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | N/A

