### PR TITLE
(fix) module pid/mem monitoring

### DIFF
--- a/lib/API/CliUx.js
+++ b/lib/API/CliUx.js
@@ -232,7 +232,7 @@ UX.dispAsTable = function(list, interact_infos) {
     if (l.pm2_env.pmx_module == true) {
       obj[key] = [
         chalk.bold(l.pm2_env.axm_options.module_version || 'N/A'),
-        l.pid,
+        l.pm2_env.axm_options.pid,
         colorStatus(status),
         l.pm2_env.restart_time ? l.pm2_env.restart_time : 0,
         l.monit ? (l.monit.cpu + '%') : 'N/A',

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -30,7 +30,8 @@ module.exports = function(God) {
 
     if (proc_key.monit.memory !== undefined &&
         proc.pm2_env.max_memory_restart !== undefined &&
-        proc.pm2_env.max_memory_restart < proc_key.monit.memory) {
+        proc.pm2_env.max_memory_restart < proc_key.monit.memory &&
+        proc.pm2_env.axm_options.pid === undefined) {
       console.log('[PM2][WORKER] Process %s restarted because it exceeds --max-memory-restart value (current_memory=%s max_memory_limit=%s [octets])', proc.pm2_env.pm_id, proc_key.monit.memory, proc.pm2_env.max_memory_restart);
       God.softReloadProcessId({
         id : proc.pm2_env.pm_id


### PR DESCRIPTION
Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

*Please update this template with something that matches your PR*

`pm2 ls` => target PID for pm2 module is now accurate.

Does not restart pm2 module if the target pid memory is over the --max-memory-restart value