### PR TITLE
Improve opts.watch

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -870,8 +870,8 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
   appConf.forEach(function(app) {
     if (opts.only && opts.only != app.name)
       return false;
-    if (!app.watch && opts.watch && (opts.watch === true || opts.watch === "true") )
-      app.watch = true;
+    if (!app.watch && opts.watch)
+      app.watch = JSON.parse(opts.watch);
     if (!app.ignore_watch && opts.ignore_watch)
       app.ignore_watch = opts.ignore_watch;
     if (opts.instances && typeof(opts.instances) === 'number')

--- a/lib/API.js
+++ b/lib/API.js
@@ -870,7 +870,7 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
   appConf.forEach(function(app) {
     if (opts.only && opts.only != app.name)
       return false;
-    if (!app.watch && opts.watch && opts.watch === true)
+    if (!app.watch && opts.watch && (opts.watch === true || opts.watch === "true") )
       app.watch = true;
     if (!app.ignore_watch && opts.ignore_watch)
       app.ignore_watch = opts.ignore_watch;


### PR DESCRIPTION
This PR Simply checks if watch option is string form of "true", this typo may happen when developers are using `echosystem.json` file and may something like this: `"watch":"true"`  

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
