### PR TITLE
Bugfix/pm2 home docker

### DIFF
--- a/bin/pm2-docker
+++ b/bin/pm2-docker
@@ -32,7 +32,6 @@ commander.version(pkg.version)
 
 function start(cmd, opts) {
   pm2 = new PM2.custom({
-    pm2_home : path.join(process.env.HOME, '.pm2'),
     secret_key : process.env.KEYMETRICS_SECRET || commander.secret,
     public_key : process.env.KEYMETRICS_PUBLIC || commander.public,
     machine_name : process.env.INSTANCE_NAME || commander.machineName,


### PR DESCRIPTION
Fix for this issue: #2580

make ```pm2-docker``` use pm2_home env variable

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2580
| License       | MIT
