### PR TITLE
(startup tmpl) wrong cmd for systemd #2590

### DIFF
--- a/lib/templates/init-scripts/systemd.tpl
+++ b/lib/templates/init-scripts/systemd.tpl
@@ -16,7 +16,7 @@ RestartSec=3
 
 ExecStart=%PM2_PATH% resurrect --no-daemon
 ExecReload=%PM2_PATH% reload all
-ExecStopPre=%PM2_PATH% kill
+ExecStop=%PM2_PATH% kill
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2590 
| License       | MIT

See issue #2590 and this post : https://bugs.freedesktop.org/show_bug.cgi?id=73177 
