### PR TITLE
Fix FreeBSD rc.conf overwrite

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -248,7 +248,7 @@ module.exports = function(CLI) {
       destination = '/etc/rc.d/pm2';
       commands = [
         'chmod +x ' + destination,
-        'echo "pm2_enable=YES" > /etc/rc.conf'
+        'echo "pm2_enable=YES" >> /etc/rc.conf'
       ];
       break;
     default:


### PR DESCRIPTION
Overwriting rc.conf on FreeBSD is very serious and will lead to a non-working system at the next reboot, as all IP address information, daemon configuration, etc. is lost.

Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | yes