### PR TITLE
Allow starting processes for each environment

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -895,7 +895,7 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
       app.ignore_watch = opts.ignore_watch;
     if (opts.instances && typeof(opts.instances) === 'number')
       app.instances = opts.instances;
-    if (app.envSpecificInstance) {
+    if (app.envSpecificInstance && opts.env) {
       app.name += ('-' + opts.env);
     }
     apps_name.push(app.name);

--- a/lib/API.js
+++ b/lib/API.js
@@ -895,6 +895,9 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
       app.ignore_watch = opts.ignore_watch;
     if (opts.instances && typeof(opts.instances) === 'number')
       app.instances = opts.instances;
+    if (app.envSpecificInstance) {
+      app.name += ('-' + opts.env);
+    }
     apps_name.push(app.name);
   });
 

--- a/lib/API.js
+++ b/lib/API.js
@@ -895,7 +895,7 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
       app.ignore_watch = opts.ignore_watch;
     if (opts.instances && typeof(opts.instances) === 'number')
       app.instances = opts.instances;
-    if (app.envSpecificInstance && opts.env) {
+    if (app.appendEnvToName && opts.env) {
       app.name += ('-' + opts.env);
     }
     apps_name.push(app.name);

--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -164,6 +164,9 @@
   "force": {
     "type": "boolean"
   },
+  "envSpecificInstance": {
+      "type": "boolean"
+  },
   "post_update": {
     "type": "array"
   },

--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -164,7 +164,7 @@
   "force": {
     "type": "boolean"
   },
-  "envSpecificInstance": {
+  "appendEnvToName": {
       "type": "boolean"
   },
   "post_update": {


### PR DESCRIPTION
Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | http://stackoverflow.com/questions/29923275/using-pm2-how-can-i-deploy-my-node-js-app-to-multiple-environments-and-ports-on
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

In `ecosystem.config.js`, the names of `apps` are given as hardcoded strings. Thus, it is impossible to start multiple instances of the same application in different environment mode. For example, if I run a particular app in production mode, and simultaneously want to start another instance of the app in the same server (but different port) in development mode, I cannot do that. As soon as I start the app in dev mode, the prod process is replaced by the dev process.

Example JSON where I face the problem - 

```javascript
    apps: [
        // First application
        {
            name: "web",
            script: "index.js",
            env: {},
            env_dev: {
                NODE_ENV: "dev",
                PORT: 4000
            },
            env_prod: {
                NODE_ENV: "prod",
                PORT: 3000
            }
        }
    ]
```

This PR tries to solve it by adding a new property to the app config (`envSpecificInstance`: true|false) and starting the new process with the environment identifier appended to the process name.

With this `pm2 start ecosystem.config.js --env prod` will start process with name `web-prod` and `pm2 start ecosystem.config.js --env dev` with name `web-dev`.