### PR TITLE
Resolve transpiler modules to locate their bin file

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -69,6 +69,12 @@ function resolveCWD(custom_path, default_path) {
   return target_cwd;
 }
 
+function getModuleBin(moduleName, binName) {
+  var modulePath = require.resolve(moduleName).split('node_modules')[0];
+
+  return path.join(modulePath, 'node_modules', '.bin', binName);
+}
+
 /**
  * Resolve app paths and replace missing values with defaults.
  * @method prepareAppConf
@@ -369,15 +375,15 @@ Common.sink.resolveInterpreter = function(app) {
    * Specific installed JS transpilers
    */
   if (app.exec_interpreter == 'ts-node') {
-    app.exec_interpreter = path.resolve(__dirname, '../node_modules/.bin/ts-node');
+    app.exec_interpreter = getModuleBin('ts-node', 'ts-node');
   }
 
   if (app.exec_interpreter == 'lsc') {
-    app.exec_interpreter = path.resolve(__dirname, '../node_modules/.bin/lsc');
+    app.exec_interpreter = getModuleBin('livescript', 'lsc');
   }
 
   if (app.exec_interpreter == 'coffee') {
-    app.exec_interpreter = path.resolve(__dirname, '../node_modules/.bin/coffee');
+    app.exec_interpreter = getModuleBin('coffee-script', 'coffee');
   }
 
   if (app.exec_interpreter != 'none' && shelljs.which(app.exec_interpreter) == null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| License       | MIT

This change builds the transpiler executable path by resolving the module and allows the transpiler to be installed as a local project dependency. It does not work if the transpiler is only installed globally.

This change enables the following new process:
npm install ts-node typescript
npm install pm2 -g
pm2 start script.ts