### PR TITLE
Make sure pm2 does not fill up systemd logs

### DIFF
--- a/lib/templates/init-scripts/systemd.tpl
+++ b/lib/templates/init-scripts/systemd.tpl
@@ -4,6 +4,7 @@ Documentation=https://pm2.keymetrics.io/
 After=network.target
 
 [Service]
+Type=forking
 User=%USER%
 LimitNOFILE=infinity
 LimitNPROC=infinity
@@ -13,8 +14,9 @@ Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/
 Environment=PM2_HOME=%HOME_PATH%
 Restart=always
 RestartSec=8
+PIDFile=%HOME_PATH%/pm2.pid
 
-ExecStart=%PM2_PATH% resurrect --no-daemon
+ExecStart=%PM2_PATH% resurrect
 ExecReload=%PM2_PATH% reload all
 ExecStop=%PM2_PATH% kill
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Fixed issue: because ExecStart is a `resurrect --no-daemon` all logs from all apps are streamed and are logged in the systemd journal, which is a different behavior than before a server reboot or a `service pm2 restart`. Changing the type to `forking` and removing the no-deamon flag seems to solve the problem.
(I am not a systemd expert, so I might be overlooking something)