### PR TITLE
Store process kill signal

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -437,7 +437,7 @@ Common.safeExtend = function(origin, add){
   if (!add || typeof add != 'object') return origin;
 
   //Ignore PM2's set environment variables from the nested env
-  var keysToIgnore = ['name', 'exec_mode', 'env', 'args', 'pm_cwd', 'exec_interpreter', 'pm_exec_path', 'node_args', 'pm_out_log_path', 'pm_err_log_path', 'pm_pid_path', 'pm_id', 'status', 'pm_uptime', 'created_at', 'unstable_restarts', 'restart_time', 'axm_actions', 'pmx_module', 'command', 'watch', 'versioning', 'vizion_runing', 'MODULE_DEBUG', 'pmx', 'axm_options', 'created_at', 'watch', 'vizion', 'axm_dynamic', 'axm_monitor', 'instances', 'automation', 'autorestart', 'node_args', 'unstable_restart', 'treekill', 'exit_code'];
+  var keysToIgnore = ['name', 'exec_mode', 'env', 'args', 'pm_cwd', 'exec_interpreter', 'pm_exec_path', 'node_args', 'pm_out_log_path', 'pm_err_log_path', 'pm_pid_path', 'pm_id', 'status', 'pm_uptime', 'created_at', 'unstable_restarts', 'restart_time', 'axm_actions', 'pmx_module', 'command', 'watch', 'versioning', 'vizion_runing', 'MODULE_DEBUG', 'pmx', 'axm_options', 'created_at', 'watch', 'vizion', 'axm_dynamic', 'axm_monitor', 'instances', 'automation', 'autorestart', 'node_args', 'unstable_restart', 'treekill', 'exit_code', 'kill_signal'];
 
   var keys = Object.keys(add);
   var i = keys.length;

--- a/lib/God.js
+++ b/lib/God.js
@@ -260,6 +260,8 @@ God.handleExit = function handleExit(clu, exit_code, kill_signal) {
     return false;
   }
 
+  proc.pm2_env.kill_signal = kill_signal || 'SIGINT';
+
   if (proc.process.pid)
     pidusage.unmonitor(proc.process.pid);
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes and no (Keymetrics.io failing)
| Fixed tickets | 
| License       | MIT

Right now there is no proper way to get kill signal via PM2 API. In some cases it would be useful to know the signal used to stop the process, e.g.: when node crashes with out-of-memory it exits with code 0 and uses SIGABRT signal, and PM2 would think there was no error and just shows 'stopped'.
