### PR TITLE
Make JSON log stream timestamp consistent

### DIFF
--- a/lib/API/Log.js
+++ b/lib/API/Log.js
@@ -205,7 +205,7 @@ Log.jsonStream = function(Client, app_name) {
 
     bus.on('process:event', function(packet) {
       console.log(JSON.stringify({
-        timestamp : moment(packet.at).toString(),
+        timestamp : moment(packet.at),
         type      : 'process_event',
         status    : packet.event,
         app_name  : packet.process.name


### PR DESCRIPTION
The timestamp when logging in JSON uses two (not influenceable) different formats when using pm2-docker.
This change makes sure all logs in JSON use the same formatting for timestamps. (ISO8601)

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT