### PR TITLE
Fix trigger API never calling callback

### DIFF
--- a/lib/API/Extra.js
+++ b/lib/API/Extra.js
@@ -163,16 +163,16 @@ module.exports = function(CLI) {
             return cb ? cb(null, results) : that.exitCli(cst.SUCCESS_EXIT);
         }
       });
-    });
 
-    that.msgProcess(cmd, function(err, data) {
-      if (err) {
-        Common.printError(err);
-        return cb ? cb(Common.retErr(err)) : that.exitCli(cst.ERROR_EXIT);
-      }
-      process_wait_count = data.process_count;
-      Common.printOut(chalk.bold('%s processes have received command %s'),
-                      data.process_count, action_name);
+      that.msgProcess(cmd, function(err, data) {
+        if (err) {
+          Common.printError(err);
+          return cb ? cb(Common.retErr(err)) : that.exitCli(cst.ERROR_EXIT);
+        }
+        process_wait_count = data.process_count;
+        Common.printOut(chalk.bold('%s processes have received command %s'),
+                        data.process_count, action_name);
+      });
     });
   };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

When using PM2 as API, sometimes it doesn't call the callback passed to trigger() function. I've found that it happens when msgProcess()'s callback is called before the bus event is received (process_wait_count still be a zero). So, we wait for bus launch, register listener on it, and then send a message to process.