### PR TITLE
Update restart command usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ $ pm2 stop     <app_name|id|'all'|json_conf>
 $ pm2 restart  <app_name|id|'all'|json_conf>
 $ pm2 delete   <app_name|id|'all'|json_conf>
 ```
-To make sure it re-evaluates enviroment variables in your `json_conf` use
+To make sure it re-evaluates enviroment variables declared in your `json_conf` pass it as argument, and optionally your custom `env` name from your `json_conf` if any:
 ```bash
-$ pm2 restart <json_conf>
+$ pm2 restart <json_conf> [--env <env_name>]
 ```
 
 To have more details on a specific process:


### PR DESCRIPTION
After 2.2 to 2.4 upgrade `restart` doesn't remember the named env it was deployed to

Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| Documentation | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

*Please update this template with something that matches your PR*
