### PR TITLE
Fix: Callbacks for process.stdout / .stderr

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -204,9 +204,12 @@ function exec(script, stds) {
         stds.std && stds.std.write && stds.std.write(log_data);
 
         // hardcoded values of special log path to not write on disk
-        if (pm2_env.pm_err_log_path !== 'NULL' && pm2_env.pm_err_log_path !== '/dev/null') {
-          stds.err.write && stds.err.write(log_data, encoding, cb);
-        };
+        if (pm2_env.pm_err_log_path !== 'NULL' && pm2_env.pm_err_log_path !== '/dev/null' && stds.err.write) {
+          stds.err.write(log_data, encoding, cb);
+        }
+        else {
+          cb();
+        }
 
         process.send({
           type : 'log:err',
@@ -238,8 +241,11 @@ function exec(script, stds) {
         stds.std && stds.std.write && stds.std.write(log_data);
 
         // hardcoded values of special log path to not write on disk
-        if (pm2_env.pm_out_log_path !== 'NULL' && pm2_env.pm_out_log_path !== '/dev/null') {
-          stds.out.write && stds.out.write(log_data);
+        if (pm2_env.pm_out_log_path !== 'NULL' && pm2_env.pm_out_log_path !== '/dev/null' && stds.out.write) {
+          stds.out.write(log_data, encoding, cb);
+        }
+        else {
+          cb();
         }
 
         process.send({

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -201,7 +201,7 @@ function exec(script, stds) {
         else
           log_data = string.toString();
 
-        stds.std && stds.std.write && stds.std.write(log_data);
+        stds.std && stds.std.write && stds.std.write(log_data, encoding);
 
         // hardcoded values of special log path to not write on disk
         if (pm2_env.pm_err_log_path !== 'NULL' && pm2_env.pm_err_log_path !== '/dev/null' && stds.err.write) {
@@ -238,7 +238,7 @@ function exec(script, stds) {
         else
           log_data = string.toString();
 
-        stds.std && stds.std.write && stds.std.write(log_data);
+        stds.std && stds.std.write && stds.std.write(log_data, encoding);
 
         // hardcoded values of special log path to not write on disk
         if (pm2_env.pm_out_log_path !== 'NULL' && pm2_env.pm_out_log_path !== '/dev/null' && stds.out.write) {

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -207,7 +207,7 @@ function exec(script, stds) {
         if (pm2_env.pm_err_log_path !== 'NULL' && pm2_env.pm_err_log_path !== '/dev/null' && stds.err.write) {
           stds.err.write(log_data, encoding, cb);
         }
-        else {
+        else if (cb) {
           cb();
         }
 
@@ -244,7 +244,7 @@ function exec(script, stds) {
         if (pm2_env.pm_out_log_path !== 'NULL' && pm2_env.pm_out_log_path !== '/dev/null' && stds.out.write) {
           stds.out.write(log_data, encoding, cb);
         }
-        else {
+        else if (cb) {
           cb();
         }
 


### PR DESCRIPTION
The overrides for `process.stdout.write` and `process.stderr.write` did not invoke the provided callbacks when they’re done.

This solution is a bit hacky because it just waits for `stds.out` and `stds.err`, respectively. A proper fix should wait for all of the downstream writes (`std.std` and/or `std.out/err` and/or `process.send`, depending on the configuration), before invoking the callback – and forward any potential errors.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no, but the same four tests also fail on `development`
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
