### PR TITLE
Patch 1

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,66 +1,19 @@
-## I'm opening this issue because:
-
-  - [ ] pm2 isn't behaving like it should do.
-  - [ ] pm2 is doing something I don't understand.
-  - [ ] pm2 is crashing.
-  - [ ] Other (_see at the end for feature requests_):
-
-## What's going wrong?
-
 <!--
-    Please a explain what you are expecting and whats actually happening
+    Thank you for contributing to PM2!
+
+    About a new issue, please check that there is no duplicate:
+         https://github.com/Unitech/pm2/search?type=Issues
+
+    If not please fill out the following questions:
 -->
 
-## How can we reproduce the problem?
+**What's going wrong?**
+**How could we reproduce this issue?**
 
-<!--
-    Please a complete description of how to reproduce the problem.
--->
+## Supporting information
 
-## General Informations:
-
- `pm2 -v` prints: 
- ``` 
- ```
-
-`node -v` prints: 
-``` 
 ```
-
-`uname -a` output for unix OR Windows version: 
+PM2 version: `pm2 -v`
+Node version: `node -v`
+Windows? Mac? Linux?
 ```
- ```
-
-`tail --lines 50 ~/.pm2/pm2.log` prints: 
-
-``` 
-```
-
-<!--
-    Thank you for contributing to PM2 !
-
-    - Please check we don't already resolved your problem:
-      https://github.com/Unitech/pm2/search?type=Issues
-
-    - Also ensure that we don't document the problem in our documentation:
-      http://pm2.keymetrics.io/docs/usage/quick-start/
-
-    For feature requests, delete the above and uncomment the section following this one. But first, review the existing feature requests
-    and make sure there isn't one that already describes the feature
-    you'd like to see added:
-      https://github.com/Unitech/pm2/issues?q=is%3Aopen+is%3Aissue+label%3A%22T%3A+Feature%22
--->
-
-<!--
-
-#### What's the feature?
-
-#### What problem is the feature intended to solve?
-
-#### Is the absence of this feature blocking you or your team? If so, how?
-
-#### Is this feature similar to an existing feature in another tool?
-
-#### Is this a feature you're prepared to implement, with support from the PM2 maintainers ?
-
--->

--- a/lib/templates/logrotate.d/pm2
+++ b/lib/templates/logrotate.d/pm2
@@ -1,4 +1,4 @@
-%HOME_PATH%/pm2.log %HOME_PATH%/logs/* {
+%HOME_PATH%/pm2.log %HOME_PATH%/logs/*.log {
         rotate 12
         weekly
         missingok


### PR DESCRIPTION
As explained in #2498

The logs are being saved as index-out-0.log and index-error-0.log.
If you just leave /home/user/.pm2/pm2.log /home/user/.pm2/logs/*, the first time logrotate runs, it generates index-out-0.log.1. The second time it runs it generates index-out-0.log.1.1, and it continues creating files for each file found, since you are including all files.
It should be reverted back to *.log or *log

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2500
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls


