### PR TITLE
Fix #2809 - Install PM2 module from Github's non-master branch

### DIFF
--- a/lib/API/Modules/Modularizer.js
+++ b/lib/API/Modules/Modularizer.js
@@ -140,21 +140,13 @@ function installModule(CLI, module_name, cb) {
 
       Common.printOut(cst.PREFIX_MSG_MOD + 'Module downloaded');
 
-      if (module_name.match(/\.tgz($|\?)/)) {
-        module_name = Utility.packageNameToModuleName(module_name);
-      }
-      else if (module_name.indexOf('/') != -1)
-        module_name = module_name.split('/')[1];
+      var canonic_module_name = Utility.getCanonicModuleName(module_name);
 
-      //pm2 install module@2.1.0-beta
-      if(module_name.indexOf('@') != -1)
-        module_name = module_name.split('@')[0]
-
-      proc_path = p.join(cst.PM2_ROOT_PATH, 'node_modules', module_name);
+      proc_path = p.join(cst.PM2_ROOT_PATH, 'node_modules', canonic_module_name);
 
       cmd = p.join(proc_path, cst.DEFAULT_MODULE_JSON);
 
-      Configuration.set(MODULE_CONF_PREFIX + ':' + module_name, 'true', function(err, data) {
+      Configuration.set(MODULE_CONF_PREFIX + ':' + canonic_module_name, 'true', function(err, data) {
         startModule(CLI, {
           cmd : cmd,
           development_mode : development_mode,
@@ -300,7 +292,7 @@ Modularizer.launchAll = function(CLI, cb) {
 Modularizer.install = function(CLI, module_name, cb) {
   Common.printOut(cst.PREFIX_MSG_MOD + 'Installing module ' + module_name);
 
-  var canonic_module_name = Utility.packageNameToModuleName(module_name);
+  var canonic_module_name = Utility.getCanonicModuleName(module_name);
 
   if (module_name == 'v8-profiler' || module_name == 'profiler') {
     installLangModule('v8-profiler', function(e) {
@@ -375,7 +367,8 @@ Modularizer.uninstall = function(CLI, module_name, cb) {
     return false;
   }
 
-  uninstallModule(CLI, module_name, cb);
+  var canonic_module_name = Utility.getCanonicModuleName(module_name);
+  uninstallModule(CLI, canonic_module_name, cb);
 };
 
 /**

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -153,19 +153,48 @@ var Utility = module.exports = {
 
     async.waterfall(flows, callback);
   },
+  
   /**
-   * Returns the module name from a .tgz package name (or the original name if it is not a valid pkg).
-   * @param {string} package_name The package name (e.g. "foo.tgz", "foo-1.0.0.tgz", "folder/foo.tgz")
-   * @return {string} the name
+   * Function parse the module name and returns it as canonic:
+   * - Makes the name based on installation filename.
+   * - Removes the Github author, module version and git branch from original name.
+   * 
+   * @param {string} module_name
+   * @returns {string} Canonic module name (without trimed parts).
+   * @example Always returns 'pm2-slack' for inputs 'ma-zal/pm2-slack', 'ma-zal/pm2-slack#own-branch',
+   *          'pm2-slack-1.0.0.tgz' or 'pm2-slack@1.0.0'.
    */
-  packageNameToModuleName: function(package_name) {
-    if (package_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)) {
-      package_name = package_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)[2];
-      if (package_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)) {
-        package_name = package_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)[1];
+  getCanonicModuleName: function(module_name) {
+    var canonic_module_name = module_name;
+      
+    // Returns the module name from a .tgz package name (or the original name if it is not a valid pkg).
+    // Input: The package name (e.g. "foo.tgz", "foo-1.0.0.tgz", "folder/foo.tgz")
+    // Output: The module name
+    if (canonic_module_name.match(/\.tgz($|\?)/)) {
+      if (canonic_module_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)) {
+        canonic_module_name = canonic_module_name.match(/^(.+\/)?([^\/]+)\.tgz($|\?)/)[2];
+        if (canonic_module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)) {
+          canonic_module_name = canonic_module_name.match(/^(.+)-[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_]+\.[0-9]+)?$/)[1];
+        }
       }
     }
-    return package_name;
+    
+    //pm2 install username/module
+    else if(canonic_module_name.indexOf('/') !== -1) {
+      canonic_module_name = canonic_module_name.split('/')[1];
+    }
+
+    //pm2 install module@2.1.0-beta
+    if(canonic_module_name.indexOf('@') !== -1) {
+      canonic_module_name = canonic_module_name.split('@')[0];
+    }
+
+    //pm2 install module#some-branch
+    if(canonic_module_name.indexOf('#') !== -1) {
+      canonic_module_name = canonic_module_name.split('#')[0];
+    }
+      
+    return canonic_module_name;
   }
 
 };


### PR DESCRIPTION
Fixed the broken installation of modules specified as Github repository with non-master branch. Fixed the broken upgrade of modules specified by Github source (old version was not been removed, therefore two instances existed in memory after upgrade).

Fixes issue #2809 .

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2809
| License       | MIT
