### PR TITLE
(bugfix) #2868: fix --raw not display previous logs

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -143,7 +143,7 @@ module.exports = function(CLI) {
         that.exitCli(cst.ERROR_EXIT);
       }
 
-      if (lines === 0 || raw)
+      if (lines === 0)
         return Log.stream(that.Client, id, raw, timestamp, exclusive);
 
       Common.printOut(chalk.bold.grey(util.format.call(this, '[TAILING] Tailing last %d lines for [%s] process%s (change the value with --lines option)', lines, id, id === 'all' ? 'es' : '')));


### PR DESCRIPTION
Fixed #2868 : now will display previous logs for raw option.