### PR TITLE
fixing the generated sudo script for non root users

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -22,12 +22,12 @@ module.exports = function(CLI) {
   function isNotRoot(platform, opts, cb) {
     if (opts.user) {
       console.log(cst.PREFIX_MSG + 'You have to run this command as root. Execute the following command:');
-      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' pm2 ' + opts.args[1].name() + ' ' + platform + ' -u ' + opts.user + ' --hp ' + process.env.HOME);
+      console.log('echo \'env PATH=$PATH:' + path.dirname(process.execPath) + ' pm2 ' + opts.args[1].name() + ' ' + platform + ' -u ' + opts.user + ' --hp ' + process.env.HOME + '\' | sudo sh');
       return cb(new Error('You have to run this with elevated rights'));
     }
     return exec('whoami', function(err, stdout, stderr) {
       console.log(cst.PREFIX_MSG + 'You have to run this command as root. Execute the following command:');
-      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' ' + require.main.filename + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + stdout.trim() + ' --hp ' + process.env.HOME);
+      console.log('echo \'sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' ' + require.main.filename + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + stdout.trim() + ' --hp ' + process.env.HOME + '\' | sudo sh');
       return cb(new Error('You have to run this with elevated rights'));
     });
   }


### PR DESCRIPTION
the original script evaluated the $PATH variable still in the user context which in some distriburions doesn't include the sbin folders. I changed it so it will be evaluated in the target (root) user context.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2892
| License       | MIT
| Doc PR        | na
