### PR TITLE
Adds timestamp to all log lines

### DIFF
--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -124,10 +124,19 @@ module.exports = function ForkMode(God) {
             app_name : cspr.pm2_env.name
           }) + '\n';
         }
-        else if (pm2_env.log_date_format)
-          log_data = moment().format(pm2_env.log_date_format) + ': ' + data.toString();
-        else
-          log_data = data.toString();
+        else {
+          var lines = data.toString().split('\n');
+          var formatted = [];
+          for (var i = 0; i < lines.length - 1; i++) {
+            if (pm2_env.log_date_format){
+              formatted.push(moment().format(pm2_env.log_date_format) + ': ' + lines[i]);
+            }
+            else {
+              formatted.push(lines[i]);
+            }
+          }
+          log_data = '\n' + formatted.join('\n');
+        }
 
         stds.std && stds.std.write && stds.std.write(log_data);
         stds.err && stds.err.write && stds.err.write(log_data);
@@ -160,10 +169,19 @@ module.exports = function ForkMode(God) {
             app_name : cspr.pm2_env.name
           }) + '\n';
         }
-        else if (pm2_env.log_date_format)
-          log_data = moment().format(pm2_env.log_date_format) + ': ' + data.toString();
-        else
-          log_data = data.toString();
+        else {
+          var lines = data.toString().split('\n');
+          var formatted = [];
+          for (var i = 0; i < lines.length - 1; i++) {
+            if (pm2_env.log_date_format){
+              formatted.push(moment().format(pm2_env.log_date_format) + ': ' + lines[i]);
+            }
+            else {
+              formatted.push(lines[i]);
+            }
+          }
+          log_data = '\n' + formatted.join('\n');
+        }
 
         stds.std && stds.std.write && stds.std.write(log_data);
         stds.out && stds.out.write && stds.out.write(log_data);


### PR DESCRIPTION
Fixes #2792 where timestamps are missing from lines in logs due to stdout stream chunking.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (log now has extra timestamps)
| Deprecations? | no
| Tests pass?   | no (stdout error as expected?)
| Fixed tickets | #2792 
| License       | MIT
