### PR TITLE
Do not ignore log_file when out(err)_file are NULL

### DIFF
--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -136,10 +136,9 @@ module.exports = function ForkMode(God) {
           data : log_data
         });
 
-        if (pm2_env.pm_err_log_path === 'NULL' ||
-            pm2_env.pm_err_log_path === '/dev/null') {
+        if ((pm2_env.pm_err_log_path === 'NULL' ||
+            pm2_env.pm_err_log_path === '/dev/null') && !pm2_env.pm_log_path)
           return false;
-        }
 
         stds.std && stds.std.write && stds.std.write(log_data);
         stds.err && stds.err.write && stds.err.write(log_data);
@@ -175,8 +174,8 @@ module.exports = function ForkMode(God) {
           data : log_data
         });
 
-        if (pm2_env.pm_out_log_path === 'NULL' ||
-            pm2_env.pm_out_log_path === '/dev/null')
+        if ((pm2_env.pm_out_log_path === 'NULL' ||
+            pm2_env.pm_out_log_path === '/dev/null') && !pm2_env.pm_log_path)
           return false;
 
         stds.std && stds.std.write && stds.std.write(log_data);

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -229,9 +229,10 @@ function exec(script, stds) {
           data : log_data
         });
 
-        if (pm2_env.pm_err_log_path === 'NULL' ||
-            pm2_env.pm_err_log_path === '/dev/null')
+        if ((pm2_env.pm_err_log_path === 'NULL' ||
+            pm2_env.pm_err_log_path === '/dev/null') && !pm2_env.pm_log_path) {
           return cb ? cb() : false;
+        }
 
         stds.std && stds.std.write && stds.std.write(log_data, encoding);
         stds.err && stds.err.write && stds.err.write(log_data, encoding, cb);
@@ -267,9 +268,10 @@ function exec(script, stds) {
           data : log_data
         });
 
-        if (pm2_env.pm_out_log_path === 'NULL' ||
-            pm2_env.pm_out_log_path === '/dev/null')
+        if ((pm2_env.pm_out_log_path === 'NULL' ||
+            pm2_env.pm_out_log_path === '/dev/null') && !pm2_env.pm_log_path) {
           return cb ? cb() : null;
+        }
 
         stds.std && stds.std.write && stds.std.write(log_data, encoding);
         stds.out && stds.out.write && stds.out.write(log_data, encoding, cb);

--- a/test/programmatic/logs.js
+++ b/test/programmatic/logs.js
@@ -104,7 +104,6 @@ describe('Programmatic log feature test', function() {
         }, 500);
       });
     });
-
   });
 
   describe('Log timestamp', function() {
@@ -197,6 +196,84 @@ describe('Programmatic log feature test', function() {
     });
   });
 
+  describe('Logs set to /dev/null', function() {
+    it('should not write to logs', function(done) {
+      pm2.start({
+        script: './echo.js',
+        error_file : '/dev/null',
+        out_file   : '/dev/null'
+      }, function(err, procs) {
+        should(err).be.null();
 
+        var out_file = procs[0].pm2_env.pm_out_log_path;
+        var err_file = procs[0].pm2_env.pm_err_log_path;
+
+        out_file.should.containEql('/dev/null');
+        err_file.should.containEql('/dev/null');
+
+        setTimeout(function() {
+          fs.readFileSync(out_file).toString().should.containEql('');
+          fs.readFileSync(err_file).toString().should.containEql('');
+          done();
+        }, 500);
+      });
+    });
+
+    it('should write to log_file and not error_file or out_file', function(done) {
+      pm2.start({
+        script: './echo.js',
+        error_file : '/dev/null',
+        out_file   : '/dev/null',
+        log_file   : 'merged.log',
+        merge_logs : true
+      }, function(err, procs) {
+        should(err).be.null();
+
+        var out_file = procs[0].pm2_env.pm_out_log_path;
+        var err_file = procs[0].pm2_env.pm_err_log_path;
+        var log_file = procs[0].pm2_env.pm_log_path;
+
+        out_file.should.containEql('/dev/null');
+        err_file.should.containEql('/dev/null');
+        log_file.should.containEql('merged.log');
+
+        setTimeout(function() {
+          fs.readFileSync(out_file).toString().should.containEql('');
+          fs.readFileSync(err_file).toString().should.containEql('');
+          fs.readFileSync(log_file).toString().should.containEql('echo.js-error');
+          fs.readFileSync(log_file).toString().should.containEql('echo.js');
+          done();
+        }, 500);
+      });
+    });
+
+    it('should write to log_file and error_file but not out_file', function(done) {
+      pm2.start({
+        script: './echo.js',
+        error_file : 'error-echo.log',
+        out_file   : '/dev/null',
+        log_file   : 'merged.log',
+        merge_logs : true
+      }, function(err, procs) {
+        should(err).be.null();
+
+        var out_file = procs[0].pm2_env.pm_out_log_path;
+        var err_file = procs[0].pm2_env.pm_err_log_path;
+        var log_file = procs[0].pm2_env.pm_log_path;
+
+        out_file.should.containEql('/dev/null');
+        err_file.should.containEql('error-echo.log');
+        log_file.should.containEql('merged.log');
+
+        setTimeout(function() {
+          fs.readFileSync(out_file).toString().should.containEql('');
+          fs.readFileSync(err_file).toString().should.containEql('echo.js-error');
+          fs.readFileSync(log_file).toString().should.containEql('echo.js-error');
+          fs.readFileSync(log_file).toString().should.containEql('echo.js');
+          done();
+        }, 500);
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
https://github.com/Unitech/pm2/issues/3045 was recently fixed an issue introduced in 2.6 but a piece of it is missing. In the event you set `out_file` or `error_file` to `/dev/null`, it ignores `log_file`.
```
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3045
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
```
