### PR TITLE
Retain multiple newlines in log stream

### DIFF
--- a/lib/API/Log.js
+++ b/lib/API/Log.js
@@ -113,8 +113,8 @@ Log.stream = function(Client, id, raw, timestamp, exclusive) {
       else
         return;
 
-      lines.forEach(function(line) {
-        if (!line) return;
+      lines.forEach(function(line, i) {
+        if (!line && i === lines.length - 1) return;
 
         if (raw)
           return process.stdout.write(util.format(line) + '\n');
@@ -171,8 +171,8 @@ Log.devStream = function(Client, id, raw, timestamp, exclusive) {
       else
         return;
 
-      lines.forEach(function(line) {
-        if (!line) return;
+      lines.forEach(function(line, i) {
+        if (!line && i === lines.length - 1) return;
 
         if (raw)
           return process.stdout.write(util.format(line) + '\n');
@@ -254,8 +254,8 @@ Log.formatStream = function(Client, id, raw, timestamp, exclusive) {
       else
         return;
 
-      lines.forEach(function(line) {
-        if (!line) {
+      lines.forEach(function(line, i) {
+        if (!line && i === lines.length - 1) {
           return;
         }
 


### PR DESCRIPTION
Currently, if any process tries to log a blank line (i.e. `\n\n`), the line is removed in streaming logs yet retained in the log file and in the tail function. This PR retains those extra newlines.

The Log.*stream methods are checking for general falsiness of each element after splitting a chunk on `\n`, presumably to remove the resulting last element that will be an empty string. We can double-check that an element is indeed the last element before ignoring it.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
