### PR TITLE
Fix applying env PM2_CONCURRENT_ACTIONS correctly

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -72,9 +72,10 @@ var csts = {
 
   // Concurrent actions when doing start/restart/reload
   CONCURRENT_ACTIONS      : (function() {
-    var concurrent_actions = parseInt(process.env.PM2_CONCURRENT_ACTIONS) || 1;
+    var default_concurrent_actions = 1;
     if (semver.satisfies(process.versions.node, '>= 4.0.0'))
-      concurrent_actions = 2;
+      default_concurrent_actions = 2;
+    var concurrent_actions = parseInt(process.env.PM2_CONCURRENT_ACTIONS) || default_concurrent_actions;
     debug('Using %d parallelism (CONCURRENT_ACTIONS)', concurrent_actions);
     return concurrent_actions;
   })(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Fixes #3036
| License       | MIT
| Doc PR        |

Now the default will be either 1 or 2 depending on node version and the environment variable will still be able to overwrite the default.

I also tried the --parallel flag first, but neither in the json config nor in the cli it works with `pm2 reload`
