### PR TITLE
Add flag to turn off auto exit with pm2-docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 *.rpm
 package-lock.json
 .DS_Store
+*.swp
+*.swo

--- a/lib/API/Containerizer.js
+++ b/lib/API/Containerizer.js
@@ -76,7 +76,7 @@ function parseAndSwitch(file_content, main_file, opts) {
 
       if (mode == 'distribution') {
         lines[i + 2] = 'COPY . /var/app';
-        lines[i + 3] = 'CMD ["pm2-docker", "--auto-exit", "' + main_file + '", "--env", "production"]';
+        lines[i + 3] = 'CMD ["pm2-docker", "' + main_file + '", "--env", "production"]';
       }
       if (mode == 'development') {
         lines[i + 2] = 'CMD ["pm2-dev", "' + main_file + '", "--env", "development"]';

--- a/lib/binaries/Runtime4Docker.js
+++ b/lib/binaries/Runtime4Docker.js
@@ -24,12 +24,12 @@ commander.version(pkg.version)
   .option('--delay <seconds>', 'delay start of configuration file by <seconds>', 0)
   .option('--web [port]', 'launch process web api on [port] (default to 9615)')
   .option('--only <application-name>', 'only act on one application of configuration')
-  .option('--auto-exit', 'exit if all processes are errored/stopped or 0 apps launched', true)
+  .option('--no-auto-exit', 'do not exit if all processes are errored/stopped or 0 apps launched')
   .option('--env [name]', 'inject env_[name] env variables in process config file')
   .option('--watch', 'watch and restart application on file change')
   .option('--error <path>', 'error log file destination (default disabled)', '/dev/null')
   .option('--output <path>', 'output log file destination (default disabled)', '/dev/null')
-  .usage('pm2-docker app.js');
+  .usage('app.js');
 
 function start(cmd, opts) {
   pm2 = new PM2.custom({
@@ -40,7 +40,9 @@ function start(cmd, opts) {
     daemon_mode : true
   });
 
-  autoExit();
+  if (commander.autoExit) {
+    autoExit();
+  }
 
   pm2.connect(function() {
 
@@ -68,6 +70,16 @@ commander.command('start <app.js|json_file>')
 if (process.argv.length == 2) {
   commander.outputHelp();
   process.exit(1);
+}
+
+var autoExitIndex = process.argv.indexOf('--auto-exit');
+if (autoExitIndex > -1) {
+  console.warn(
+    "Warning: --auto-exit has been removed, as it's now the default behavior" +
+    "; if you want to disable it, use the new --no-auto-exit flag."
+  );
+
+  process.argv.splice(autoExitIndex, 1);
 }
 
 commander.parse(process.argv);

--- a/test/fixtures/containerizer/Dockerfile.dev
+++ b/test/fixtures/containerizer/Dockerfile.dev
@@ -11,4 +11,4 @@ RUN npm install
 
 ## DEVELOPMENT MODE
 ENV NODE_ENV=development
-CMD ["pm2-docker", "start", "--auto-exit", "index.js"]
+CMD ["pm2-docker", "start", "index.js"]

--- a/test/fixtures/containerizer/Dockerfile.prod
+++ b/test/fixtures/containerizer/Dockerfile.prod
@@ -12,4 +12,4 @@ RUN npm install
 ## PRODUCTION MODE
 ENV NODE_ENV=production
 COPY . /var/app/
-CMD ["pm2-docker", "start", "--auto-exit", "index.js"]
+CMD ["pm2-docker", "start", "index.js"]

--- a/test/programmatic/containerizer.mocha.js
+++ b/test/programmatic/containerizer.mocha.js
@@ -16,7 +16,7 @@ describe('Containerizer unit tests', function() {
   var res_lines_prod = ['## DISTRIBUTION MODE',
                         'ENV NODE_ENV=production',
                         'COPY . /var/app',
-                        'CMD ["pm2-docker", "--auto-exit", "index.js", "--env", "production"]'];
+                        'CMD ["pm2-docker", "index.js", "--env", "production"]'];
 
   after(function(done) {
     fs.unlink(Dockerfile, done);


### PR DESCRIPTION
Because we want auto exit to be on by default for pm2-docker, the flag needs to be changed to explicitly turn it off. See the example at https://tj.github.io/commander.js/#Command.prototype.option for a "simple boolean defaulting to true".

The suggested fix was:
```js
if (commander.autoExit !== false) {
 autoExit();
}
```
But I couldn't find a way to actually pass "false" as a value from the CLI.

If you would like to add a test for this change, l could use some help on that.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (print a warning message if --auto-exit is provided though)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3206 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pull/116
