### PR TITLE
fix pm2 install http://modules

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -14,6 +14,7 @@ var path   = require('path');
 var cst    = require('../constants.js');
 var async  = require('async');
 var util   = require('util');
+var url    = require('url');
 
 var Utility = module.exports = {
   getDate : function() {
@@ -211,9 +212,10 @@ var Utility = module.exports = {
 
     //pm2 install https://github.com/user/module
     if(canonic_module_name.indexOf('http') !== -1) {
-      canonic_module_name = canonic_module_name.split('/').pop();
+      var uri = url.parse(canonic_module_name);
+      canonic_module_name = uri.pathname.split('/').pop();
     }
-    
+
     //pm2 install file:///home/user/module
     else if(canonic_module_name.indexOf('file://') === 0) {
       canonic_module_name = canonic_module_name.replace(/\/$/, '').split('/').pop();

--- a/test/interface/utility.mocha.js
+++ b/test/interface/utility.mocha.js
@@ -24,6 +24,9 @@ describe('Utility', function() {
       assert(Utility.getCanonicModuleName('file:///home/user/pm2-slack') === 'pm2-slack');
       assert(Utility.getCanonicModuleName('file://./pm2-slack') === 'pm2-slack');
       assert(Utility.getCanonicModuleName('file:///home/user/pm2-slack/') === 'pm2-slack');
+      assert(Utility.getCanonicModuleName('http-server') === 'http-server');
+      assert(Utility.getCanonicModuleName('http://registry.com:12/modules/my-module?test=true') === 'my-module');
+      assert(Utility.getCanonicModuleName('http://registry.com:12/modules/http-my-module?test=true') === 'http-my-module');
     });
   });
 


### PR DESCRIPTION
Use Node native url parser for `pm2 install http://modules` to eliminate query values.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A