### PR TITLE
- Initial es6 modules support

### DIFF
--- a/lib/ProcessContainerFork.js
+++ b/lib/ProcessContainerFork.js
@@ -76,5 +76,6 @@ else
 
 // Change some values to make node think that the user's application
 // was started directly such as `node app.js`
+process.mainModule = process.mainModule || {};
 process.mainModule.loaded = false;
 require.main = process.mainModule;


### PR DESCRIPTION
Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

From node v8.8.1 we received unstable es6 modules support with flag --experimental-modules.
(more about it here: https://nodejs.org/api/esm.html)

Es6 modules has broken code which depends on commonJS module system. This pull request allows initially with some hacks support es6 modules.

Note: this provides full backward compatibility with CommonJS projects.
Note: I'd hope this will be included in next pm2 release - while es6 modules are still experimental feature they are worse supporting right now.
I was not really sure where and how shall I pull request it. Hope dev branch was the right choice.
I created simple project for demonstrating es6 modules usage: https://github.com/vpotseluyko/test-es6-pm2