### PR TITLE
Implement windowsHide in God spawn methods

### DIFF
--- a/lib/God/ClusterMode.js
+++ b/lib/God/ClusterMode.js
@@ -49,7 +49,7 @@ module.exports = function ClusterMode(God) {
       // { "args": ["foo", "bar"], "env": { "foo1": "bar1" }} will be parsed to
       // { "args": "foo, bar", "env": "[object Object]"}
       // So we passing a stringified JSON here.
-      clu = cluster.fork({pm2_env: JSON.stringify(env_copy)});
+      clu = cluster.fork({pm2_env: JSON.stringify(env_copy), windowsHide: true});
     } catch(e) {
       God.logAndGenerateError(e);
       return cb(e);

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -94,6 +94,7 @@ module.exports = function ForkMode(God) {
         var cspr = spawn(command, args, {
           env      : pm2_env,
           detached : true,
+          windowsHide: true,
           cwd      : pm2_env.pm_cwd || process.cwd(),
           stdio    : ['pipe', 'pipe', 'pipe', 'ipc'] //Same as fork() in node core
         });


### PR DESCRIPTION
Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2182 2 years old issue :D 
| License       | MIT
| Doc PR        | n/a

Just changed God spawn methods (cluster.fork options are given to spawn in nodejs code).

Thanks @milichev about the feature update in nodejs!

NB: we may want to add this option to our detached spawns:

```
M       lib/API/Startup.js
M       lib/Client.js
M       lib/Daemon.js
M       lib/Interactor/InteractorDaemonizer.js
M       lib/Satan.js
```

let me know if needed.