### PR TITLE
raw output should keep the original output stream.

### DIFF
--- a/lib/API/Log.js
+++ b/lib/API/Log.js
@@ -56,7 +56,7 @@ Log.tail = function(apps_list, lines, raw, callback) {
       console.log(chalk.grey('%s last %d lines:'), app.path, lines);
       output.forEach(function(out) {
         if (raw)
-          return console.log(out);
+          return app.type === 'err' ? console.error : console.log(out);
         if (app.type === 'out')
           process.stdout.write(chalk.green(pad(DEFAULT_PADDING, app.app_name)  + ' | '));
         else if (app.type === 'err')

--- a/lib/API/Log.js
+++ b/lib/API/Log.js
@@ -56,7 +56,7 @@ Log.tail = function(apps_list, lines, raw, callback) {
       console.log(chalk.grey('%s last %d lines:'), app.path, lines);
       output.forEach(function(out) {
         if (raw)
-          return app.type === 'err' ? console.error : console.log(out);
+          return app.type === 'err' ? console.error(out) : console.log(out);
         if (app.type === 'out')
           process.stdout.write(chalk.green(pad(DEFAULT_PADDING, app.app_name)  + ' | '));
         else if (app.type === 'err')


### PR DESCRIPTION
in docker/kubernetes setup, error logging depends on errors being on stderr. My app does this by default but when PM2 takes over, all logs gets combined into stdout. Which makes it really hard to automatically detect the errors. 


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
