### PR TITLE
Change type definitions to reflect correct return type of describe()

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -114,7 +114,7 @@ export function killDaemon(errback: ErrProcDescCallback): void;
  * a process id, or the string “all” to indicate that all scripts should be restarted.
  * @param errback
  */
-export function describe(process: string|number, errback: ErrProcDescCallback): void;
+export function describe(process: string|number, errback: ErrProcDescsCallback): void;
 
 /**
  * Gets the list of running processes being managed by pm2.


### PR DESCRIPTION
See https://github.com/Unitech/pm2/blob/master/lib/API.js#L1654

The describe() function returns an array, not an object. The return typehint 
should be ErrProcDescsCallback, not ErrProcDescCallback, to reflect
the correct return type.

Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | None
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
