### PR TITLE
FreeBSD Startup Support

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -41,7 +41,8 @@ module.exports = function(CLI) {
       'update-rc.d': 'upstart',
       'chkconfig'  : 'systemv',
       'rc-update'  : 'openrc',
-      'launchctl'  : 'launchd'
+      'launchctl'  : 'launchd',
+      'sysrc'      : 'rcd'
     };
     var init_systems = Object.keys(hash_map);
 
@@ -138,6 +139,14 @@ module.exports = function(CLI) {
       commands = [
         'launchctl remove com.' + launchd_service_name,
         'rm ' + destination
+      ];
+      break;
+    case 'rcd':
+      service_name = (opts.serviceName || 'pm2_' + user);
+      commands = [
+        '/usr/local/etc/rc.d/' + service_name + ' stop',
+        'sysrc -x ' + service_name  + '_enable',
+        'rm /usr/local/etc/rc.d/' + service_name
       ];
     };
 
@@ -256,10 +265,11 @@ module.exports = function(CLI) {
     case 'freebsd':
     case 'rcd':
       template = getTemplate('rcd');
-      destination = '/etc/rc.d/' + service_name;
+      service_name = (opts.serviceName || 'pm2_' + user);
+      destination = '/usr/local/etc/rc.d/' + service_name;
       commands = [
-        'chmod +x ' + destination,
-        'echo "pm2_enable=YES" >> /etc/rc.conf'
+        'chmod 755 ' + destination,
+        'sysrc ' + service_name + '_enable=YES'
       ];
       break;
     case 'openrc':
@@ -281,7 +291,8 @@ module.exports = function(CLI) {
     template = template.replace(/%PM2_PATH%/g, process.mainModule.filename)
       .replace(/%NODE_PATH%/g, path.dirname(process.execPath))
       .replace(/%USER%/g, user)
-      .replace(/%HOME_PATH%/g, opts.hp ? path.resolve(opts.hp, '.pm2') : cst.PM2_ROOT_PATH);
+      .replace(/%HOME_PATH%/g, opts.hp ? path.resolve(opts.hp) : cst.PM2_ROOT_PATH)
+      .replace(/%SERVICE_NAME%/g, service_name);
 
     Common.printOut(chalk.bold('Platform'), platform);
     Common.printOut(chalk.bold('Template'));

--- a/lib/templates/init-scripts/rcd.tpl
+++ b/lib/templates/init-scripts/rcd.tpl
@@ -6,59 +6,39 @@
 
 . /etc/rc.subr
 
-name=pm2
-rcvar=${name}_enable
+name="%SERVICE_NAME%"
+rcvar="%SERVICE_NAME%_enable"
+
+start_cmd="pm2_start"
+stop_cmd="pm2_stop"
+reload_cmd="pm2_reload"
+status_cmd="pm2_status"
+extra_commands="reload status"
+
+pm2()
+{
+  env PATH="$PATH:%NODE_PATH%" PM2_HOME="%HOME_PATH%" su -m "%USER%" -c "%PM2_PATH% $*"
+}
+
+pm2_start()
+{
+  pm2 resurrect
+}
+
+pm2_stop()
+{
+  pm2 kill
+}
+
+pm2_reload()
+{
+  pm2 reload all
+}
+
+pm2_status()
+{
+  pm2 list
+}
 
 load_rc_config $name
-
-: ${pm2_user="%USER%"}
-
-command="%PM2_PATH%"
-pidfile="/home/${pm2_user}/.pm2/${name}.pid"
-start_cmd="${name}_start"
-stop_cmd="${name}_stop"
-reload_cmd="${name}_reload"
-status_cmd="${name}_status"
-
-extra_commands="reload"
-
-super() {
-        su - "${pm2_user}" -c "$*"
-}
-
-pm2_start() {
-        unset "${rc_flags}_cmd"
-        if pm2_running; then
-                echo "Pm2 is already running, 'pm2 list' to see running processes"
-        else
-                echo "Starting pm2."
-                super $command resurrect
-        fi
-}
-
-pm2_stop() {
-        echo "Stopping ${name}..."
-        #super $command dump
-        super $command delete all
-        super $command kill
-}
-
-pm2_reload() {
-        echo "Reloading ${name}"
-        super $command reload all
-}
-
-pm2_status() {
-        super $command list
-}
-
-pm2_running() {
-        process_id=$(pgrep -F ${pidfile})
-        if [ "${process_id}" -gt 0 ]; then
-                return 0
-        else
-                return 1
-        fi
-}
-
 run_rc_command "$1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3287
| License       | MIT

**Startup.js**

```
function detectInitSystem() {
  var hash_map = {
    'systemctl'  : 'systemd',
    'update-rc.d': 'upstart',
    'chkconfig'  : 'systemv',
    'rc-update'  : 'openrc',
    'launchctl'  : 'launchd',
    'sysrc'      : 'rcd'
  };
```

we can use [sysrc](https://www.freebsd.org/cgi/man.cgi?query=sysrc) to detect FreeBSD > 9.2

`service_name = (opts.serviceName || 'pm2_' + user);`

[rcvar]( https://www.freebsd.org/cgi/man.cgi?query=rc.d) may not contain a -

`destination = '/usr/local/etc/rc.d/' + service_name;`

port [scripts](https://www.freebsd.org/doc/en/articles/rc-scripting/article.html) should go to /usr/local/etc/rc.d/

```
.replace(/%HOME_PATH%/g, opts.hp ? path.resolve(opts.hp, '.pm2') : cst.PM2_ROOT_PATH);
.replace(/%HOME_PATH%/g, opts.hp ? path.resolve(opts.hp) : cst.PM2_ROOT_PATH)

env PM2_HOME=/srv/www/pm2 pm2 startup -u www
pm2 startup -u www --hp /srv/www/pm2
```

currently it is impossible to create --hp paths without a .pm2 directory
with path.resolve(opts.hp) PM2_HOME and --hp behave the same way

`.replace(/%SERVICE_NAME%/g, service_name);`

fb8fbe1 allows custom service names for startup scripts but no script actually uses the service name

**rcd.tpl**

```
name="%SERVICE_NAME%"
rcvar="%SERVICE_NAME%_enable"
```

allows custom service names and multiple startup scripts for the same user

```
pm2()
{
  env PATH="$PATH:%NODE_PATH%" PM2_HOME="%HOME_PATH%" su -m "%USER%" -c "%PM2_PATH% $*"
}
```

allows to run PM2 even for system accounts without home directory in any user writable PM2_HOME
