### PR TITLE
improve building of rpm and deb packages.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,8 +9,8 @@ pipeline:
       - gem install --no-ri --no-rdoc fpm
       - gem install --no-ri --no-rdoc package_cloud
       - ./packager/build-dist.sh
-      - ./packager/build-deb-rpm.sh
       - echo $${PACKAGECLOUD_TOKEN} > /root/.packagecloud
+      - ./packager/build-deb-rpm.sh
       - ./packager/publish_deb_rpm.sh
     secrets: ['packagecloud_token']
     when:

--- a/packager/build-deb-rpm.sh
+++ b/packager/build-deb-rpm.sh
@@ -13,8 +13,11 @@ ensureAvailable lintian
 ensureAvailable rpmbuild
 
 PACKAGE_TMPDIR=tmp/debian_pkg
+echo "Cleaning PACKAGE_TMPDIR..."
+rm -rf $PACKAGE_TMPDIR
+
 PM2_VERSION=`node dist/bin/pm2 --version`
-VERSION=$PM2_VERSION"."$DRONE_BUILD_NUMBER
+VERSION=$PM2_VERSION"-"$DRONE_BUILD_NUMBER
 TARBALL_NAME=dist/pm2-v$PM2_VERSION.tar.gz
 OUTPUT_DIR=artifacts
 
@@ -44,6 +47,51 @@ mv $PACKAGE_TMPDIR/dist/node_modules $PACKAGE_TMPDIR/usr/share/pm2/
 mv $PACKAGE_TMPDIR/dist/package.json $PACKAGE_TMPDIR/usr/share/pm2/
 cp packager/debian/copyright $PACKAGE_TMPDIR/usr/share/doc/pm2/copyright
 
+INSTALLED_SIZE=`du -sk $PACKAGE_TMPDIR | cut -f 1`
+sed -i "s/__VERSION__/$VERSION/" packager/debian/control
+sed -i "s/__INSTALLED_SIZE__/$INSTALLED_SIZE/" packager/debian/control
+
+mkdir -p $PACKAGE_TMPDIR/etc/default
+echo "[+] Adding default configuration file for pm2 to package."
+cat <<EOF > $PACKAGE_TMPDIR/etc/default/pm2
+##
+## Default configuration var for pm2
+##
+
+# Path for PM2's home (configuration files, modules, sockets... etc)
+export PM2_HOME=/etc/pm2
+
+# User that own files in PM2_HOME
+export PM2_SOCKET_USER=\`id -u pm2\`
+
+# Group that own files in PM2_HOME
+export PM2_SOCKET_GROUP=\`id -g pm2\`
+
+EOF
+
+mkdir -p $PACKAGE_TMPDIR/etc/systemd/system/
+echo "[+] Adding systemd configuration for pm2 to package."
+cat <<EOF > $PACKAGE_TMPDIR/etc/systemd/system/pm2.service
+[Unit]
+Description=PM2 process manager
+Documentation=https://pm2.keymetrics.io/
+After=network.target
+
+[Service]
+Type=forking
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+PIDFile=/etc/pm2/pm2.pid
+
+ExecStart=/usr/bin/pm2 resurrect
+ExecReload=/usr/bin/pm2 reload all
+ExecStop=/usr/bin/pm2 kill
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 # These are unneeded and throw lintian lint errors
 rm -f $PACKAGE_TMPDIR/usr/share/pm2/node_modules/node-uuid/benchmark/bench.gnu
 find $PACKAGE_TMPDIR/usr/share/pm2 \( -name '*.md' -o  -name '*.md~' -o -name '*.gitmodules' \) -delete
@@ -53,19 +101,33 @@ rm -rf $PACKAGE_TMPDIR/dist
 
 # Currently the "binaries" are JavaScript files that expect to be in the same
 # directory as the libraries, so we can't just copy them directly to /usr/bin.
-# Symlink them instead.
+# We set the path and pass the args in another script instead.
+
 mkdir -p $PACKAGE_TMPDIR/usr/bin/
-ln -s ../share/pm2/bin/pm2 $PACKAGE_TMPDIR/usr/bin/pm2
 
-# Common FPM parameters for all packages we'll build using FPM
-FPM="fpm --input-type dir --chdir $PACKAGE_TMPDIR --name pm2 --version $VERSION "`
-  `"--vendor 'Keymetrics <tech@keymetrics.io>' --maintainer 'Alexandre Strzelewicz <tech@keymetrics.io>' "`
-  `"--url https://pm2.io/ --license AGPLv3 --description '$(cat packager/debian/description)'"
+cat <<EOF > $PACKAGE_TMPDIR/usr/bin/pm2
+#!/bin/bash
+. /etc/default/pm2
+/usr/share/pm2/bin/pm2 \$@
+EOF
+chmod a+x $PACKAGE_TMPDIR/usr/bin/pm2
 
-FPM_COMMON_OPTS="--architecture noarch --depends nodejs --category 'Development/Languages' ."
-
-##### Build RPM (CentOS, Fedora) package
-eval "$FPM --output-type rpm $FPM_COMMON_OPTS"
+#### Build RPM
+fpm --input-type dir --chdir $PACKAGE_TMPDIR \
+    --name pm2 \
+    --url https://pm2.io/ \
+    --category 'Development/Languages' \
+    --license AGPLv3 \
+    --description '$(cat packager/debian/description)' \
+    --vendor 'Keymetrics <tech@keymetrics.io>' \
+    --maintainer 'Alexandre Strzelewicz <tech@keymetrics.io>' \
+    --version $PM2_VERSION --iteration $DRONE_BUILD_NUMBER \
+    --after-install packager/rhel/postinst \
+    --before-remove packager/rhel/prerm \
+    --after-remove packager/rhel/postrm \
+    --architecture noarch \
+    --depends nodejs \
+    --output-type rpm .
 
 ##### Adapt files for Debian-like distro
 mkdir -p $PACKAGE_TMPDIR/DEBIAN
@@ -76,8 +138,9 @@ cp packager/debian/lintian-overrides $PACKAGE_TMPDIR/usr/share/lintian/overrides
 sed -i 's/env node/env nodejs/' $PACKAGE_TMPDIR/usr/share/pm2/bin/pm2
 
 # Replace variables in Debian package control file
-INSTALLED_SIZE=`du -sk $PACKAGE_TMPDIR | cut -f 1`
-sed -e "s/\$VERSION/$VERSION/;s/\$INSTALLED_SIZE/$INSTALLED_SIZE/" < packager/debian/control.in > $PACKAGE_TMPDIR/DEBIAN/control
+cp packager/debian/* $PACKAGE_TMPDIR/DEBIAN/.
+
+ls $PACKAGE_TMPDIR/DEBIAN/
 
 ##### Build DEB (Debian, Ubuntu) package
-eval "$FPM --output-type deb $FPM_COMMON_OPTS"
+fakeroot dpkg-deb -b $PACKAGE_TMPDIR "pm2_"$VERSION"_all.deb"

--- a/packager/debian/control
+++ b/packager/debian/control
@@ -1,14 +1,12 @@
 Package: pm2
-Version: $VERSION
-Depends: nodejs
+Version: __VERSION__
+Depends: nodejs (>= 6.12.2)
 Conflicts: nodejs (<< 0.12.0)
 Section: devel
 Priority: optional
 Architecture: all
-Installed-Size: $INSTALLED_SIZE
+Installed-Size: __INSTALLED_SIZE__
 Maintainer: Alexandre Strzelewicz <alexandre@keymetrics.io>
 Homepage: http://pm2.io/
-Description: Production Process Manager.
- PM2: Process Manager for Node.js.
- .
+Description: PM2 - Process Manager for Node.js.
  PM2 is a Process Manager mainly for Node.js that allows to automatically increase performance and stability while enhancing the process management experience for developer and DevOps.

--- a/packager/debian/postinst
+++ b/packager/debian/postinst
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+adduser --quiet --system \
+	--group --home /etc/pm2 \
+	--gecos "PM2 Process Manager" pm2
+
+if hash systemctl 2> /dev/null; then
+    {
+	systemctl enable "pm2.service" && \
+	    systemctl start "pm2.service"
+    } || echo "pm2 could not be registered or started"
+elif hash service 2> /dev/null; then
+    service "pm2" start || echo "pm2 could not be registered or started"
+else
+    echo 'Ingnoring pm2 auto-startup.'
+    echo 'You can run `pm2 startup` as root to do it manually.'
+fi

--- a/packager/debian/postrm
+++ b/packager/debian/postrm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+deluser --quiet pm2 || true

--- a/packager/debian/prerm
+++ b/packager/debian/prerm
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if hash systemctl 2> /dev/null; then
+    systemctl disable "pm2.service" && \
+	systemctl stop "pm2.service" || \
+	    echo "pm2 wasn't even running!"
+elif hash service 2> /dev/null; then
+    service "pm2" stop || echo "pm2 wasn't even running!"
+else
+    echo "Your system does not appear to use upstart, systemd or sysv, so pm2 could not be stopped"
+    echo 'Unless these systems were removed since install, no processes have been left running'
+fi

--- a/packager/rhel/postinst
+++ b/packager/rhel/postinst
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p /etc/pm2
+
+adduser --system \
+	--home-dir /etc/pm2 \
+	--comment "PM2 Process Manager" pm2
+
+chown -R pm2:pm2 /etc/pm2
+
+if hash systemctl 2> /dev/null; then
+    {
+	systemctl enable "pm2.service" && \
+	    systemctl start "pm2.service"
+    } || echo "pm2 could not be registered or started"
+elif hash service 2> /dev/null; then
+    service "pm2" start || echo "pm2 could not be registered or started"
+else
+    echo 'Ingnoring pm2 auto-startup.'
+    echo 'You can run `pm2 startup` as root to do it manually.'
+fi

--- a/packager/rhel/postrm
+++ b/packager/rhel/postrm
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+userdel pm2 || true
+groupdel pm2 || true

--- a/packager/rhel/prerm
+++ b/packager/rhel/prerm
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if hash systemctl 2> /dev/null; then
+    systemctl disable "pm2.service" && \
+	systemctl stop "pm2.service" || \
+	    echo "pm2 wasn't even running!"
+elif hash service 2> /dev/null; then
+    service "pm2" stop || echo "pm2 wasn't even running!"
+else
+    echo "Your system does not appear to use upstart, systemd or sysv, so pm2 could not be stopped"
+    echo 'Unless these systems were removed since install, no processes have been left running'
+fi

--- a/packager/setup.deb.sh
+++ b/packager/setup.deb.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+REPOSITORY_OWNER="Keymetrics"
+
+show_banner ()
+{
+    echo 
+    echo "__/\\\\\\\\\\\\\\\\\\\\\\\\\\____/\\\\\\\\____________/\\\\\\\\____/\\\\\\\\\\\\\\\\\\_____"
+    echo " _\\/\\\\\\/////////\\\\\\_\\/\\\\\\\\\\\\________/\\\\\\\\\\\\__/\\\\\\///////\\\\\\___"
+    echo "  _\\/\\\\\\_______\\/\\\\\\_\\/\\\\\\//\\\\\\____/\\\\\\//\\\\\\_\\///______\\//\\\\\\__"
+    echo "   _\\/\\\\\\\\\\\\\\\\\\\\\\\\\\/__\\/\\\\\\\\///\\\\\\/\\\\\\/_\\/\\\\\\___________/\\\\\\/___"
+    echo "    _\\/\\\\\\/////////____\\/\\\\\\__\\///\\\\\\/___\\/\\\\\\________/\\\\\\//_____"
+    echo "     _\\/\\\\\\_____________\\/\\\\\\____\\///_____\\/\\\\\\_____/\\\\\\//________"
+    echo "      _\\/\\\\\\_____________\\/\\\\\\_____________\\/\\\\\\___/\\\\\\/___________"
+    echo "       _\\/\\\\\\_____________\\/\\\\\\_____________\\/\\\\\\__/\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\_"
+    echo "        _\\///______________\\///______________\\///__\\///////////////__"
+    echo "                          Community Edition Setup"
+    echo
+}
+
+unknown_os ()
+{
+    echo "Unfortunately, your operating system distribution and version might not be supported by this script."
+    echo
+    echo "You can override the OS detection by setting os= and dist= prior to running this script."
+    echo "For example, to force Ubuntu Trusty: os=ubuntu dist=trusty ./script.sh"
+    echo
+    echo "For more informations, please read the documentation on http://pm2.io/"
+    exit 1
+}
+
+gpg_check ()
+{
+    echo "Checking for gpg..."
+    if command -v gpg > /dev/null; then
+	echo "Detected gpg..."
+    else
+	echo "Installing gnupg for GPG verification..."
+	apt-get install -y gnupg
+	if [ "$?" -ne "0" ]; then
+	    echo "Unable to install GPG! Your base system has a problem; please check your default OS's package repositories because GPG should work."
+	    echo "Repository installation aborted."
+	    exit 1
+	fi
+    fi
+}
+
+curl_check ()
+{
+    echo "Checking for curl..."
+    if command -v curl > /dev/null; then
+	echo "Detected curl..."
+    else
+	echo "Installing curl..."
+	apt-get install -q -y curl
+	if [ "$?" -ne "0" ]; then
+	    echo "Unable to install curl! Your base system has a problem; please check your default OS's package repositories because curl should work."
+	    echo "Repository installation aborted."
+	    exit 1
+	fi
+    fi
+}
+
+install_debian_keyring ()
+{
+    if [ "${os}" = "debian" ]; then
+	echo "Installing debian-archive-keyring which is needed for installing "
+	echo "apt-transport-https on many Debian systems."
+	apt-get install -y debian-archive-keyring &> /dev/null
+    fi
+}
+
+
+detect_os ()
+{
+    if [[ ( -z "${os}" ) && ( -z "${dist}" ) ]]; then
+	# some systems dont have lsb-release yet have the lsb_release binary and
+	# vice-versa
+	if [ -e /etc/lsb-release ]; then
+	    . /etc/lsb-release
+
+	    if [ "${ID}" = "raspbian" ]; then
+		os=${ID}
+		dist=`cut --delimiter='.' -f1 /etc/debian_version`
+	    else
+		os=${DISTRIB_ID}
+		dist=${DISTRIB_CODENAME}
+
+		if [ -z "$dist" ]; then
+		    dist=${DISTRIB_RELEASE}
+		fi
+	    fi
+
+	elif [ `which lsb_release 2>/dev/null` ]; then
+	    dist=`lsb_release -c | cut -f2`
+	    os=`lsb_release -i | cut -f2 | awk '{ print tolower($1) }'`
+
+	elif [ -e /etc/debian_version ]; then
+	    # some Debians have jessie/sid in their /etc/debian_version
+	    # while others have '6.0.7'
+	    os=`cat /etc/issue | head -1 | awk '{ print tolower($1) }'`
+	    if grep -q '/' /etc/debian_version; then
+		dist=`cut --delimiter='/' -f1 /etc/debian_version`
+	    else
+		dist=`cut --delimiter='.' -f1 /etc/debian_version`
+	    fi
+
+	else
+	    unknown_os
+	fi
+    fi
+
+    if [ -z "$dist" ]; then
+	unknown_os
+    fi
+
+    # remove whitespace from OS and dist name
+    os="${os// /}"
+    dist="${dist// /}"
+
+    echo "Detected operating system as $os/$dist."
+}
+
+install_node ()
+{
+    # Official install method of
+    # https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
+    # without using sudo.
+    curl -sL https://deb.nodesource.com/setup_9.x | bash - || exit 1
+}
+
+main ()
+{
+    show_banner
+    detect_os
+    curl_check
+    gpg_check
+
+    # Need to first run apt-get update so that apt-transport-https can be
+    # installed
+    echo -n "Running apt-get update... "
+    apt-get update &> /dev/null
+    echo "done."
+
+    # Install the debian-archive-keyring package on debian systems so that
+    # apt-transport-https can be installed next
+    install_debian_keyring
+
+    echo -n "Installing apt-transport-https... "
+    apt-get install -y apt-transport-https &> /dev/null
+    echo "done."
+
+    install_node
+
+    gpg_key_url="https://packagecloud.io/$REPOSITORY_OWNER/pm2/gpgkey"
+    apt_config_url="https://packagecloud.io/install/repositories/$REPOSITORY_OWNER/pm2/config_file.list?os=${os}&dist=${dist}&source=script"
+
+    apt_source_path="/etc/apt/sources.list.d/"$REPOSITORY_OWNER"_pm2.list"
+
+    echo -n "Installing $apt_source_path..."
+
+    # create an apt config file for this repository
+    curl -sSf "${apt_config_url}" > $apt_source_path
+    curl_exit_code=$?
+
+    if [ "$curl_exit_code" = "22" ]; then
+	echo "This script is unable to download the repository definition."
+	echo
+	[ -e $apt_source_path ] && rm $apt_source_path
+	unknown_os
+    elif [ "$curl_exit_code" = "35" -o "$curl_exit_code" = "60" ]; then
+	echo "curl is unable to connect to packagecloud.io over TLS when running: "
+	echo "    curl ${apt_config_url}"
+	echo "This is usually due to one of two things:"
+	echo
+	echo " 1.) Missing CA root certificates (make sure the ca-certificates package is installed)"
+	echo " 2.) An old version of libssl. Try upgrading libssl on your system to a more recent version"
+	echo
+	echo "Contact support@packagecloud.io with information about your system for help."
+	[ -e $apt_source_path ] && rm $apt_source_path
+	exit 1
+    elif [ "$curl_exit_code" -gt "0" ]; then
+	echo
+	echo "Unable to run: "
+	echo "    curl ${apt_config_url}"
+	echo
+	echo "Double check your curl installation and try again."
+	[ -e $apt_source_path ] && rm $apt_source_path
+	exit 1
+    else
+	echo "done."
+    fi
+
+    echo -n "Importing packagecloud gpg key... "
+    # import the gpg key
+    curl -L "${gpg_key_url}" 2> /dev/null | apt-key add - &>/dev/null
+    echo "done."
+
+    echo -n "Running apt-get update... "
+    # update apt on this system
+    apt-get update &> /dev/null
+    echo "done."
+
+    echo -n "Installing PM2..."
+    apt-get install -y pm2 &> /dev/null
+    echo "done."
+
+    CURR_USER=$SUDO_USER
+    if [ "$CURR_USER" == "" ]; then
+	CURR_USER=$USER
+    fi
+    
+    if [ "$CURR_USER" == "root" ] || [ "$CURR_USER" == "" ]; then
+	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	echo "WARNING: You are either running this script as root or the"
+	echo "         \$USER variable is empty. In order to have a"
+	echo "         working PM2 installation, you need to add your"
+	echo "         user in the pm2 group using the following"
+	echo "         command:      usermod -aG pm2 <username>"
+	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    else
+	echo -n "Adding $CURR_USER to group pm2..."
+	usermod -aG pm2 $CURR_USER
+	echo "done."
+    fi
+    echo
+    echo "Installation done."
+    echo "You now need to logout of your system and login again in order to be able to use the 'pm2' command."
+}
+
+main
+

--- a/packager/setup.rpm.sh
+++ b/packager/setup.rpm.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+REPOSITORY_OWNER="Keymetrics"
+
+show_banner ()
+{
+    echo 
+    echo "__/\\\\\\\\\\\\\\\\\\\\\\\\\\____/\\\\\\\\____________/\\\\\\\\____/\\\\\\\\\\\\\\\\\\_____"
+    echo " _\\/\\\\\\/////////\\\\\\_\\/\\\\\\\\\\\\________/\\\\\\\\\\\\__/\\\\\\///////\\\\\\___"
+    echo "  _\\/\\\\\\_______\\/\\\\\\_\\/\\\\\\//\\\\\\____/\\\\\\//\\\\\\_\\///______\\//\\\\\\__"
+    echo "   _\\/\\\\\\\\\\\\\\\\\\\\\\\\\\/__\\/\\\\\\\\///\\\\\\/\\\\\\/_\\/\\\\\\___________/\\\\\\/___"
+    echo "    _\\/\\\\\\/////////____\\/\\\\\\__\\///\\\\\\/___\\/\\\\\\________/\\\\\\//_____"
+    echo "     _\\/\\\\\\_____________\\/\\\\\\____\\///_____\\/\\\\\\_____/\\\\\\//________"
+    echo "      _\\/\\\\\\_____________\\/\\\\\\_____________\\/\\\\\\___/\\\\\\/___________"
+    echo "       _\\/\\\\\\_____________\\/\\\\\\_____________\\/\\\\\\__/\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\_"
+    echo "        _\\///______________\\///______________\\///__\\///////////////__"
+    echo "                          Community Edition Setup"
+    echo
+}
+
+unknown_os ()
+{
+    echo "Unfortunately, your operating system distribution and version might not be supported by this script."
+    echo
+    echo "You can override the OS detection by setting os= and dist= prior to running this script."
+    echo "For example, to force Ubuntu Trusty: os=ubuntu dist=trusty ./script.sh"
+    echo
+    echo "For more informations, please read the documentation on http://pm2.io/"
+    exit 1
+}
+
+curl_check ()
+{
+    echo "Checking for curl..."
+    if command -v curl > /dev/null; then
+	echo "Detected curl..."
+    else
+	echo "Installing curl..."
+	yum install -d0 -e0 -y curl
+    fi
+}
+
+
+detect_os ()
+{
+    if [[ ( -z "${os}" ) && ( -z "${dist}" ) ]]; then
+	if [ -e /etc/os-release ]; then
+	    . /etc/os-release
+	    os=${ID}
+	    if [ "${os}" = "poky" ]; then
+		dist=`echo ${VERSION_ID}`
+	    elif [ "${os}" = "sles" ]; then
+		dist=`echo ${VERSION_ID}`
+	    elif [ "${os}" = "opensuse" ]; then
+		dist=`echo ${VERSION_ID}`
+	    else
+		dist=`echo ${VERSION_ID} | awk -F '.' '{ print $1 }'`
+	    fi
+
+	elif [ `which lsb_release 2>/dev/null` ]; then
+	    # get major version (e.g. '5' or '6')
+	    dist=`lsb_release -r | cut -f2 | awk -F '.' '{ print $1 }'`
+
+	    # get os (e.g. 'centos', 'redhatenterpriseserver', etc)
+	    os=`lsb_release -i | cut -f2 | awk '{ print tolower($1) }'`
+
+	elif [ -e /etc/oracle-release ]; then
+	    dist=`cut -f5 --delimiter=' ' /etc/oracle-release | awk -F '.' '{ print $1 }'`
+	    os='ol'
+
+	elif [ -e /etc/fedora-release ]; then
+	    dist=`cut -f3 --delimiter=' ' /etc/fedora-release`
+	    os='fedora'
+
+	elif [ -e /etc/redhat-release ]; then
+	    os_hint=`cat /etc/redhat-release  | awk '{ print tolower($1) }'`
+	    if [ "${os_hint}" = "centos" ]; then
+		dist=`cat /etc/redhat-release | awk '{ print $3 }' | awk -F '.' '{ print $1 }'`
+		os='centos'
+	    elif [ "${os_hint}" = "scientific" ]; then
+		dist=`cat /etc/redhat-release | awk '{ print $4 }' | awk -F '.' '{ print $1 }'`
+		os='scientific'
+	    else
+		dist=`cat /etc/redhat-release  | awk '{ print tolower($7) }' | cut -f1 --delimiter='.'`
+		os='redhatenterpriseserver'
+	    fi
+
+	else
+	    aws=`grep -q Amazon /etc/issue`
+	    if [ "$?" = "0" ]; then
+		dist='6'
+		os='aws'
+	    else
+		unknown_os
+	    fi
+	fi
+    fi
+
+    if [[ ( -z "${os}" ) || ( -z "${dist}" ) ]]; then
+	unknown_os
+    fi
+
+    # remove whitespace from OS and dist name
+    os="${os// /}"
+    dist="${dist// /}"
+
+    echo "Detected operating system as ${os}/${dist}."
+}
+
+finalize_yum_repo ()
+{
+    echo "Installing pygpgme to verify GPG signatures..."
+    yum install -y pygpgme --disablerepo='Keymetrics_pm2'
+    pypgpme_check=`rpm -qa | grep -qw pygpgme`
+    if [ "$?" != "0" ]; then
+	echo
+	echo "WARNING: "
+	echo "The pygpgme package could not be installed. This means GPG verification is not possible for any RPM installed on your system. "
+	echo "To fix this, add a repository with pygpgme. Usualy, the EPEL repository for your system will have this. "
+	echo "More information: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F"
+	echo
+
+	# set the repo_gpgcheck option to 0
+	sed -i'' 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/Keymetrics_pm2.repo
+    fi
+
+    echo "Installing yum-utils..."
+    yum install -y yum-utils --disablerepo='Keymetrics_pm2'
+    yum_utils_check=`rpm -qa | grep -qw yum-utils`
+    if [ "$?" != "0" ]; then
+	echo
+	echo "WARNING: "
+	echo "The yum-utils package could not be installed. This means you may not be able to install source RPMs or use other yum features."
+	echo
+    fi
+
+    echo "Generating yum cache for Keymetrics_pm2..."
+    yum -q makecache -y --disablerepo='*' --enablerepo='Keymetrics_pm2'
+}
+
+finalize_zypper_repo ()
+{
+    zypper --gpg-auto-import-keys refresh Keymetrics_pm2
+}
+
+install_node ()
+{
+    curl --silent --location https://rpm.nodesource.com/setup_9.x | bash - || exit 1
+}
+
+install_pm2 ()
+{
+    PKG_MANAGER=$1
+    echo -n "Installing PM2 with $PKG_MANAGER..."
+    $PKG_MANAGER install -y pm2 2> /dev/null
+
+    CURR_USER=$SUDO_USER
+    if [ "$CURR_USER" == "" ]; then
+	CURR_USER=$USER
+    fi
+    
+    if [ "$CURR_USER" == "root" ] || [ "$CURR_USER" == "" ]; then
+	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+	echo "WARNING: You are either running this script as root or the"
+	echo "         \$USER variable is empty. In order to have a"
+	echo "         working PM2 installation, you need to add your"
+	echo "         user in the pm2 group using the following"
+	echo "         command:      usermod -aG pm2 <username>"
+	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    else
+	echo -n "Adding $CURR_USER to group pm2..."
+	usermod -aG pm2 $CURR_USER
+	echo "done."
+    fi    
+}
+
+main ()
+{
+    show_banner
+    detect_os
+    curl_check
+
+    yum_repo_config_url="https://packagecloud.io/install/repositories/$REPOSITORY_OWNER/pm2/config_file.repo?os=${os}&dist=${dist}&source=script"
+
+    if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then
+	yum_repo_path=/etc/zypp/repos.d/Keymetrics_pm2.repo
+    else
+	yum_repo_path=/etc/yum.repos.d/Keymetrics_pm2.repo
+	install_node
+    fi
+    
+    echo "Downloading repository file: ${yum_repo_config_url}"
+
+    curl -sSf "${yum_repo_config_url}" > $yum_repo_path
+    curl_exit_code=$?
+
+    if [ "$curl_exit_code" = "22" ]; then
+	echo
+	echo
+	echo -n "Unable to download repo config from: "
+	echo "${yum_repo_config_url}"
+	echo
+	echo "This usually happens if your operating system is not supported by "
+	echo "packagecloud.io, or this script's OS detection failed."
+	echo
+	echo "You can override the OS detection by setting os= and dist= prior to running this script."
+	echo "You can find a list of supported OSes and distributions on our website: https://packagecloud.io/docs#os_distro_version"
+	echo
+	echo "For example, to force CentOS 6: os=el dist=6 ./script.sh"
+	echo
+	echo "If you are running a supported OS, please email support@packagecloud.io and report this."
+	[ -e $yum_repo_path ] && rm $yum_repo_path
+	exit 1
+    elif [ "$curl_exit_code" = "35" -o "$curl_exit_code" = "60" ]; then
+	echo
+	echo "curl is unable to connect to packagecloud.io over TLS when running: "
+	echo "    curl ${yum_repo_config_url}"
+	echo
+	echo "This is usually due to one of two things:"
+	echo
+	echo " 1.) Missing CA root certificates (make sure the ca-certificates package is installed)"
+	echo " 2.) An old version of libssl. Try upgrading libssl on your system to a more recent version"
+	echo
+	echo "Contact support@packagecloud.io with information about your system for help."
+	[ -e $yum_repo_path ] && rm $yum_repo_path
+	exit 1
+    elif [ "$curl_exit_code" -gt "0" ]; then
+	echo
+	echo "Unable to run: "
+	echo "    curl ${yum_repo_config_url}"
+	echo
+	echo "Double check your curl installation and try again."
+	[ -e $yum_repo_path ] && rm $yum_repo_path
+	exit 1
+    else
+	echo "done."
+    fi
+
+    if [ "${os}" = "sles" ] || [ "${os}" = "opensuse" ]; then
+	finalize_zypper_repo
+	install_pm2 zypper
+    else
+	finalize_yum_repo
+	install_pm2 yum
+    fi
+
+    echo
+    echo "Installation done."
+    echo "You now need to logout of your system and login again in order to be able to use the 'pm2' command."
+}
+
+main
+


### PR DESCRIPTION
add systemd configuration.
set pm2's home to /etc/pm2.
create user/group on installation - clean after remove
add automatic setup script for debian-like and rhel-like distro.

To install on debian-like systems using a one-liner:
`curl -sL https://raw.githubusercontent.com/Rohja/pm2/drone_build/packager/setup.deb.sh | sudo -E bash -`

To install on rhel-like systems using a one-liner:
`curl -sL https://raw.githubusercontent.com/Rohja/pm2/drone_build/packager/setup.rpm.sh | sudo -E bash -`

@Unitech 