### PR TITLE
raw output should keep the original output stream in docker.

### DIFF
--- a/lib/API/Log.js
+++ b/lib/API/Log.js
@@ -117,7 +117,7 @@ Log.stream = function(Client, id, raw, timestamp, exclusive) {
         if (!line || line.length === 0) return;
 
         if (raw)
-          return process.stdout.write(util.format(line) + '\n');
+          return type === 'err' ? process.stderr.write(util.format(line) + '\n') : process.stdout.write(util.format(line) + '\n');
 
         if (timestamp)
           process.stdout.write(chalk['dim'](chalk.grey(moment().format(timestamp) + ' ')));


### PR DESCRIPTION
if use pm2-docker and pass --raw ,all logs gets combined into stdout.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3316 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls


