### PR TITLE
Add env to StartOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -387,6 +387,10 @@ export interface StartOptions {
   write?: any;
   sourceMapSupport?: any;
   disableSourceMapSupport?: any;
+  /**
+   * The environment variables to pass on to the process.
+   */
+  env?: { [key: string]: string; };
 }
 
 // Types


### PR DESCRIPTION
Add missing `env` to the TypeScript definition.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes