### PR TITLE
Fix build number deb rpm

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,6 @@ pipeline:
     image: keymetrics/alpine-pm2-builder:latest
     environment:
       - AWS_REPO_BUCKET=alpine-apk.pm2.io
-      - PM2_TARGET_VERSION=2.7.2
     secrets: ['apk_rsa_priv_key', 'apk_rsa_pub_key', 'aws_access_key_id', 'aws_secret_access_key']
     when:
       event: tag          

--- a/packager/build-deb-rpm.sh
+++ b/packager/build-deb-rpm.sh
@@ -17,7 +17,7 @@ echo "Cleaning PACKAGE_TMPDIR..."
 rm -rf $PACKAGE_TMPDIR
 
 PM2_VERSION=`node dist/bin/pm2 --version`
-VERSION=$PM2_VERSION"-"$DRONE_BUILD_NUMBER
+VERSION=$PM2_VERSION
 TARBALL_NAME=dist/pm2-v$PM2_VERSION.tar.gz
 OUTPUT_DIR=artifacts
 
@@ -121,7 +121,7 @@ fpm --input-type dir --chdir $PACKAGE_TMPDIR \
     --description '$(cat packager/debian/description)' \
     --vendor 'Keymetrics <tech@keymetrics.io>' \
     --maintainer 'Alexandre Strzelewicz <tech@keymetrics.io>' \
-    --version $PM2_VERSION --iteration $DRONE_BUILD_NUMBER \
+    --version $PM2_VERSION \
     --after-install packager/rhel/postinst \
     --before-remove packager/rhel/prerm \
     --after-remove packager/rhel/postrm \

--- a/packager/publish_deb_rpm.sh
+++ b/packager/publish_deb_rpm.sh
@@ -2,7 +2,7 @@
 
 REPOSITORY_NAME="keymetrics/pm2"
 
-for OSDIST in 'ubuntu/xenial' 'ubuntu/yakkety' 'ubuntu/zesty' 'ubuntu/artful' 'debian/wheezy' 'debian/jessie' 'debian/stretch' 'debian/buster' 'raspbian/wheezy' 'raspbian/jessie' 'raspbian/stretch' 'raspbian/buster'
+for OSDIST in 'ubuntu/trusty' 'ubuntu/xenial' 'ubuntu/yakkety' 'ubuntu/zesty' 'ubuntu/artful' 'debian/wheezy' 'debian/jessie' 'debian/stretch' 'debian/buster' 'raspbian/wheezy' 'raspbian/jessie' 'raspbian/stretch' 'raspbian/buster'
 do
     package_cloud push $REPOSITORY_NAME/$OSDIST `find -name "*.deb"`
 done


### PR DESCRIPTION
What this PR fix (according to private issues):

- APK Build was set to a fix version because of the `PM2_TARGET_VERSION` environment variable (used for dev/debug) being present in Drone configuration.

- RPM/DEB files don't use "build number" as part or their versions.

- DEB file is also uploaded for Ubuntu's older LTS version still active (ubuntu/trusty - 14.04)