### PR TITLE
feat: allow pm2 to enable v8 data collecting from pmx

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -85,6 +85,7 @@ commander.version(pkg.version)
   .option('--disable-trace', 'disable transaction tracing with km')
   .option('--attach', 'attach logging after your start/restart/stop/reload')
   .option('--sort <field_name:sort>', 'sort process according to field\'s name')
+  .option('--v8', 'enable v8 data collecting')
   .usage('[cmd] app');
 
 commander.on('--help', function() {

--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -192,6 +192,11 @@
       "boolean"
     ]
   },
+  "v8": {
+    "type": [
+      "boolean"
+    ]
+  },
   "increment_var": {
     "type": "string"
   },

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -33,7 +33,8 @@ delete process.env.pm2_env;
   if (process.env.pmx !== 'false')
     require('pmx').init({
       transactions: process.env.km_link == 'true' && process.env.trace == 'true' || false,
-      http: process.env.km_link == 'true' || false
+      http: process.env.km_link == 'true' || false,
+      v8: process.env.v8 === 'true' || false
     });
 
   var stdFile     = pm2_env.pm_log_path;


### PR DESCRIPTION
Add v8 option into commander to enable data collection from v8.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
