### PR TITLE
feat: allow pm2 to install a set of module as one single command and …

### DIFF
--- a/lib/API/Modules/Modularizer.js
+++ b/lib/API/Modules/Modularizer.js
@@ -21,6 +21,14 @@ var mkdirp = require('mkdirp');
 
 var MODULE_CONF_PREFIX = 'module-db-v2';
 
+var KNOWN_MODULES = {
+  'deep-monitoring': {
+    'dependencies': ['v8-profiler-node8', 'gc-stats', 'event-loop-inspector']
+  },
+  'gc-stats': {name: 'gc-stats'},
+  'event-loop-inspector': {name: 'event-loop-inspector'}
+};
+
 /**
  * PM2 Module System.
  * Features:
@@ -32,100 +40,100 @@ var MODULE_CONF_PREFIX = 'module-db-v2';
  * - Auto discover script to launch (first it checks the apps field, then bin and finally main attr)
  * - Generate sample module via pm2 module:generate <module_name>
  */
-Modularizer.install = function(CLI, module_name, opts, cb) {
-  Common.printOut(cst.PREFIX_MSG_MOD + 'Installing module ' + module_name);
+Modularizer.install = function (CLI, moduleName, opts, cb) {
+  Common.printOut(cst.PREFIX_MSG_MOD + 'Installing module ' + moduleName);
 
-  var canonic_module_name = Utility.getCanonicModuleName(module_name);
+  var canonicModuleName = Utility.getCanonicModuleName(moduleName);
 
-  if (module_name == 'v8-profiler' || module_name == 'profiler') {
-    installLangModule('v8-profiler-node8', function(err) {
-      if (err) {
-        Common.printError(cst.PREFIX_MSG_MOD_ERR + chalk.bold.green('Profiling installation has FAILED (checkout previous logs)'));
-        return cb(err);
+  if (KNOWN_MODULES.hasOwnProperty(moduleName)) {
+    var currentModule = KNOWN_MODULES[moduleName];
+
+    if (currentModule && currentModule.hasOwnProperty('dependencies')) {
+      var functionList = [];
+      for (var i = 0; i < currentModule.dependencies.length; i++) {
+        functionList.push((function (index) {
+          return function (callback) {
+            installModuleByName(currentModule.dependencies[index], function (err) {
+              callback(null, {module: currentModule.dependencies[index], err: err});
+            }, false);
+          };
+        })(i));
       }
 
-      Common.printOut(cst.PREFIX_MSG + chalk.bold.green('V8 profiling ENABLED'));
-      return cb();
-    });
+      async.parallel(functionList, function (err, results) {
+        for (var i = 0; i < results.length; i++) {
+          if (results[i].err) {
+            err = results[i].err;
+            Common.printError(cst.PREFIX_MSG_MOD_ERR + chalk.bold.green(results[i].module + ' installation has FAILED (checkout previous logs)'));
+          } else {
+            Common.printOut(cst.PREFIX_MSG + chalk.bold.green(results[i].module + ' ENABLED'));
+          }
+        }
+
+        cb(err);
+      });
+    } else {
+      installModuleByName(currentModule.name, cb);
+    }
+
     return false;
   }
 
-  if (module_name === 'gc-stats') {
-    installLangModule('gc-stats', function(err) {
-      if (err) {
-        Common.printError(cst.PREFIX_MSG_MOD_ERR + chalk.bold.green('gc-stats installation has FAILED (checkout previous logs)'));
-        return cb(err);
-      }
-
-      Common.printOut(cst.PREFIX_MSG + chalk.bold.green('gc-stats ENABLED'));
-      return cb();
-    });
+  if (moduleName === 'v8-profiler' || moduleName === 'profiler') {
+    installModuleByName('v8-profiler-node8', cb);
     return false;
   }
 
-  if (module_name === 'event-loop-inspector') {
-    installLangModule('event-loop-inspector', function(err) {
-      if (err) {
-        Common.printError(cst.PREFIX_MSG_MOD_ERR + chalk.bold.green('event-loop-inspector installation has FAILED (checkout previous logs)'));
-        return cb(err);
-      }
-
-      Common.printOut(cst.PREFIX_MSG + chalk.bold.green('event-loop-inspector ENABLED'));
-      return cb();
-    });
-    return false;
-  }
-
-  if (module_name.indexOf('typescript') > -1) {
+  if (moduleName.indexOf('typescript') > -1) {
     // Special dependency install
-    return installLangModule(module_name, function(e) {
-      installLangModule('ts-node@latest', function(e) {
+    return installLangModule(moduleName, function (e) {
+      installLangModule('ts-node@latest', function (e) {
         Common.printOut(cst.PREFIX_MSG + chalk.bold.green('Typescript support enabled'));
         return cb(e);
       });
     });
   }
 
-  if (module_name == 'livescript') {
-    return installLangModule('livescript', function(e) {
+  if (moduleName === 'livescript') {
+    return installLangModule('livescript', function (e) {
       Common.printOut(cst.PREFIX_MSG + chalk.bold.green('Livescript support enabled'));
       return cb(e);
     });
   }
 
-  if (module_name.indexOf('coffee-script') > -1) {
-    return installLangModule(module_name, function(e) {
+  if (moduleName.indexOf('coffee-script') > -1) {
+    return installLangModule(moduleName, function (e) {
       Common.printOut(cst.PREFIX_MSG + chalk.bold.green('Coffeescript v1 support enabled'));
       return cb(e);
     });
   }
 
-  if (module_name.indexOf('coffeescript') > -1) {
-    return installLangModule(module_name, function(e) {
+  if (moduleName.indexOf('coffeescript') > -1) {
+    return installLangModule(moduleName, function (e) {
       Common.printOut(cst.PREFIX_MSG + chalk.bold.green('Coffeescript v2 support enabled'));
       return cb(e);
     });
   }
 
-  moduleExist(CLI, canonic_module_name, function(exists) {
+  moduleExist(CLI, canonicModuleName, function (exists) {
     if (exists) {
       // Update
       Common.printOut(cst.PREFIX_MSG_MOD + 'Module already installed. Updating.');
 
       // Create a backup
-      Rollback.backup(module_name);
+      Rollback.backup(moduleName);
 
       return uninstallModule(CLI, {
-        module_name : canonic_module_name,
-        deep_uninstall : false
-      }, function(err) {
-        return Modularizer.installModule(CLI, module_name, opts, cb);
+        module_name: canonicModuleName,
+        deep_uninstall: false
+      }, function () {
+        return Modularizer.installModule(CLI, moduleName, opts, cb);
       });
     }
 
     // Install
-    Modularizer.installModule(CLI, module_name, opts, cb);
-  })
+    Modularizer.installModule(CLI, moduleName, opts, cb);
+  });
 };
 
 Modularizer.installModule = function(CLI, module_name, opts, cb) {
@@ -568,6 +576,26 @@ Modularizer.generateSample = function(app_name, cb) {
     samplize(module_name);
   });
 };
+
+function installModuleByName (moduleName, cb, verbose) {
+  if (!moduleName || moduleName.length === 0) {
+    return cb(new Error('No module name !'));
+  }
+
+  if (typeof verbose === 'undefined') {
+    verbose = true;
+  }
+
+  installLangModule(moduleName, function (err) {
+    if (err) {
+      if (verbose) { Common.printError(cst.PREFIX_MSG_MOD_ERR + chalk.bold.green(moduleName + ' installation has FAILED (checkout previous logs)')); }
+      return cb(err);
+    }
+
+    if (verbose) { Common.printOut(cst.PREFIX_MSG + chalk.bold.green(moduleName + ' ENABLED')); }
+    return cb();
+  });
+}
 
 function installLangModule(module_name, cb) {
   var node_module_path = path.resolve(path.join(__dirname, '../../../'));


### PR DESCRIPTION
Allow pm2 to install gc-stats, V8 profiler and event-loop-inspector with a single command.
Refactor code to install module.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
