### PR TITLE
Adding string[] to "watch" value in StartOptions (TypeScript definition file)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -375,7 +375,7 @@ export interface StartOptions {
   /**
    * If set to true, the application will be restarted on change of the script file.
    */
-  watch?: boolean;
+  watch?: boolean|string[];
   /**
    * (Default: false) By default, pm2 will only start a script if that script isn’t
    * already running (a script is a path to an application, not the name of an application


### PR DESCRIPTION
Unless I'm missing something, this argument should accept an array of paths like the JSON configuration files.