### PR TITLE
fix #3470: do not call process.exit(), if PM2 is not running with a s…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ artifacts
 .editorconfig
 .bithoundrc
 dist
+.idea

--- a/lib/Daemon.js
+++ b/lib/Daemon.js
@@ -89,7 +89,9 @@ Daemon.prototype.innerStart = function(cb) {
     console.error(e.stack || e);
   }
 
-  this.handleSignals();
+  if (require.main === module) {
+    this.handleSignals();
+  }
 
   /**
    * Pub system for real time notifications


### PR DESCRIPTION
…tandalone daemon. in this case, hook signals and call pm2.killDaemon() first. it will delete all running apps.

Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3470
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

*Please update this template with something that matches your PR*
