### PR TITLE
Update downloads badge to point to graph of downloads over time 📈 instead of duplicating link to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
    <img src="https://badge.fury.io/js/pm2.svg" alt="npm version" height="18">
 </a>
 
-<a href="https://www.npmjs.com/package/pm2" title="PM2 on NPM">
+<a href="https://npmcharts.com/compare/pm2?minimal=true" title="PM2 on NPM">
   <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/pm2.svg?style=flat-square"/>
 </a>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

*Please update this template with something that matches your PR*


Hi! I noticed that your "npm" badge and "downloads" badge currently both point to the same page for the project on npmjs.org  

I was wondering if you might prefer having the download badge point to a [download chart](https://npmcharts.com/compare/redux-form?minimal=true) instead?

If not, feel free to close and apologies for the drive-by PR 😄