### PR TITLE
fix: use polyfill module for copySync with node 4.x

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -7,6 +7,7 @@ var debug  = require('debug')('pm2:cli:startup');
 var chalk  = require('chalk');
 var path   = require('path');
 var fs     = require('fs');
+const fsExtra = require('fs-extra');
 var async  = require('async');
 var exec   = require('child_process').exec;
 var Common = require('../Common.js');
@@ -396,7 +397,7 @@ module.exports = function(CLI) {
         // Back up dump file
         try {
           if (fs.existsSync(cst.DUMP_FILE_PATH)) {
-            fs.copyFileSync(cst.DUMP_FILE_PATH, cst.DUMP_BACKUP_FILE_PATH);
+            fsExtra.copySync(cst.DUMP_FILE_PATH, cst.DUMP_BACKUP_FILE_PATH);
           }
         } catch (e) {
           console.error(e.stack || e);
@@ -411,7 +412,7 @@ module.exports = function(CLI) {
           try {
             // try to backup file
             if(fs.existsSync(cst.DUMP_BACKUP_FILE_PATH)) {
-              fs.copyFileSync(cst.DUMP_BACKUP_FILE_PATH, cst.DUMP_FILE_PATH);
+              fsExtra.copySync(cst.DUMP_BACKUP_FILE_PATH, cst.DUMP_FILE_PATH);
             }
           } catch (e) {
             // don't keep broken file

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -12,6 +12,7 @@
  */
 
 var fs            = require('fs');
+const fsExtra     = require('fs-extra');
 var path          = require('path');
 var async         = require('async');
 var os            = require('os');
@@ -155,7 +156,7 @@ module.exports = function(God) {
       // Back up dump file
       try {
         if (fs.existsSync(cst.DUMP_FILE_PATH)) {
-          fs.copyFileSync(cst.DUMP_FILE_PATH, cst.DUMP_BACKUP_FILE_PATH);
+          fsExtra.copySync(cst.DUMP_FILE_PATH, cst.DUMP_BACKUP_FILE_PATH);
         }
       } catch (e) {
         console.error(e.stack || e);
@@ -169,7 +170,7 @@ module.exports = function(God) {
         try {
           // try to backup file
           if(fs.existsSync(cst.DUMP_BACKUP_FILE_PATH)) {
-            fs.copyFileSync(cst.DUMP_BACKUP_FILE_PATH, cst.DUMP_FILE_PATH);
+            fsExtra.copySync(cst.DUMP_BACKUP_FILE_PATH, cst.DUMP_FILE_PATH);
           }
         } catch (e) {
           // don't keep broken file

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "debug": "^3.0",
     "eventemitter2": "5.0.1",
     "fclone": "1.0.11",
+    "fs-extra": "^5.0.0",
     "mkdirp": "0.5.1",
     "moment": "^2.19",
     "needle": "^2.2.0",


### PR DESCRIPTION
copyFileSync is only available for node 8.5.
Use polyfill module to be compatible with node 4.x

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
