### PR TITLE
feat: add kill_retry_time argument

### DIFF
--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -217,5 +217,9 @@
   "windowsHide": {
     "type": "boolean",
     "default" : true
+  },
+  "kill_retry_time": {
+    "type": "number",
+    "default" : 100
   }
 }

--- a/lib/God/Methods.js
+++ b/lib/God/Methods.js
@@ -167,9 +167,9 @@ module.exports = function(God) {
         clearInterval(timer);
         return cb(null, true);
       }
-      console.log('pid=%d msg=failed to kill - retrying in 100ms', pid);
+      console.log('pid=%d msg=failed to kill - retrying in %dms', pid, pm2_env.kill_retry_time);
       return false;
-    }, 100);
+    }, pm2_env.kill_retry_time);
 
     timeout = setTimeout(function() {
       clearInterval(timer);


### PR DESCRIPTION
Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

*Please update this template with something that matches your PR*

Too many logs are output at shutdown with graceful shutdown.

`
PM2        | pid=4382 msg=failed to kill - retrying in 100ms
PM2        | pid=4399 msg=failed to kill - retrying in 100ms
PM2        | pid=4364 msg=failed to kill - retrying in 100ms
PM2        | pid=4365 msg=failed to kill - retrying in 100ms
PM2        | pid=4382 msg=failed to kill - retrying in 100ms
PM2        | pid=4399 msg=failed to kill - retrying in 100ms
PM2        | pid=4364 msg=failed to kill - retrying in 100ms
PM2        | pid=4365 msg=failed to kill - retrying in 100ms
PM2        | pid=4382 msg=failed to kill - retrying in 100ms
PM2        | pid=4399 msg=failed to kill - retrying in 100ms
PM2        | pid=4364 msg=failed to kill - retrying in 100ms
PM2        | pid=4365 msg=failed to kill - retrying in 100ms
...........
...........
`

I think I should be able to set a retry time.
