### PR TITLE
Start the ecosystem file in PWD by default

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -253,7 +253,7 @@ function patchCommanderArg(cmd) {
 //
 // Start command
 //
-commander.command('start <file|json|stdin|app_name|pm_id...>')
+commander.command('start [file|json|stdin|app_name|pm_id...]')
   .option('--watch', 'Watch folder for changes')
   .option('--fresh', 'Rebuild Dockerfile')
   .option('--daemon', 'Run container in Daemon mode (debug purposes)')
@@ -280,6 +280,9 @@ commander.command('start <file|json|stdin|app_name|pm_id...>')
     else {
       // Commander.js patch
       cmd = patchCommanderArg(cmd);
+      if (cmd.length === 0) {
+        cmd = [cst.APP_CONF_DEFAULT_FILE];
+      }
       async.forEachLimit(cmd, 1, function(script, next) {
         pm2.start(script, commander, next);
       }, function(err) {


### PR DESCRIPTION
`pm2 start` with no arguments now tries to start the ecosystem file in PWD.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
