### PR TITLE
Set ecosystem.config.js as the default ecosystem file

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -32,7 +32,7 @@
 - [Without Keymetrics](#without-keymetrics)
 - [With Keymetrics](#with-keymetrics)
 
-### Deployment - ecosystem.json
+### Deployment - ecosystem.config.js
 
 - [Getting started with deployment](#deployment)
 - [Deployment options](#deployment-help)

--- a/constants.js
+++ b/constants.js
@@ -28,7 +28,7 @@ var csts = {
 
   TEMPLATE_FOLDER         : p.join(__dirname, 'lib/templates'),
 
-  APP_CONF_DEFAULT_FILE   : 'ecosystem.json',
+  APP_CONF_DEFAULT_FILE   : 'ecosystem.config.js',
   APP_CONF_TPL            : 'ecosystem.tpl',
   APP_CONF_TPL_SIMPLE     : 'ecosystem-simple.tpl',
   SAMPLE_CONF_FILE        : 'sample-conf.js',

--- a/lib/API/Modules/Modularizer.js
+++ b/lib/API/Modules/Modularizer.js
@@ -47,7 +47,7 @@ var KNOWN_MODULES = {
  * - Generate sample module via pm2 module:generate <module_name>
  */
 Modularizer.install = function (CLI, moduleName, opts, cb) {
-  // if user want to install module from ecosystem.json file
+  // if user want to install module from ecosystem.config.js file
   // it can also be a custom json file's name
   if (!moduleName || moduleName.length === 0 || moduleName.indexOf('.json') > 0) {
     var file = moduleName || cst.APP_CONF_DEFAULT_FILE;

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -260,7 +260,7 @@ Common.isConfigFile = function(filename) {
 };
 
 /**
- * Parses a config file like ecosystem.json. Supported formats: JS, JSON, JSON5, YAML.
+ * Parses a config file like ecosystem.config.js. Supported formats: JS, JSON, JSON5, YAML.
  * @param {string} confString  contents of the config file
  * @param {string} filename    path to the config file
  * @return {Object} config object


### PR DESCRIPTION
Set ecosystem.config.js as the default ecosystem file

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
