### PR TITLE
Start local ecosystem file by default

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -265,7 +265,7 @@ function patchCommanderArg(cmd) {
 //
 // Start command
 //
-commander.command('start <name|file|ecosystem|id...>')
+commander.command('start [name|file|ecosystem|id...]')
   .option('--watch', 'Watch folder for changes')
   .option('--fresh', 'Rebuild Dockerfile')
   .option('--daemon', 'Run container in Daemon mode (debug purposes)')


### PR DESCRIPTION
Set the first argument of pm2 start an option rather than a required argument.

The merge of the two last week PRs have overwritten that change.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
