### PR TITLE
Attempt to improve treekill

### DIFF
--- a/lib/TreeKill.js
+++ b/lib/TreeKill.js
@@ -1,41 +1,14 @@
 'use strict';
-
-// From https://raw.githubusercontent.com/pkrumins/node-tree-kill/master/index.js
-
-var childProcess = require('child_process');
-var spawn = childProcess.spawn;
-var exec = childProcess.exec;
+var pidtree = require('pidtree');
 
 module.exports = function (pid, signal, callback) {
-  var tree = {};
-  var pidsToProcess = {};
-  tree[pid] = [];
-  pidsToProcess[pid] = 1;
+  pidtree(pid, {root: true}, function(err, pids) {
+    if (err) {
+      console.error('Error while reading process tree', err)
+    }
 
-  switch (process.platform) {
-  case 'win32':
-    exec('taskkill /pid ' + pid + ' /T /F', { windowsHide: true }, callback);
-    break;
-  case 'darwin':
-    buildProcessTree(pid, tree, pidsToProcess, function (parentPid) {
-      return spawn('pgrep', ['-P', parentPid]);
-    }, function () {
-      killAll(tree, signal, callback);
-    });
-    break;
-    // case 'sunos':
-    //     buildProcessTreeSunOS(pid, tree, pidsToProcess, function () {
-    //         killAll(tree, signal, callback);
-    //     });
-    //     break;
-  default: // Linux
-    buildProcessTree(pid, tree, pidsToProcess, function (parentPid) {
-      return spawn('ps', ['-o', 'pid', '--no-headers', '--ppid', parentPid]);
-    }, function () {
-      killAll(tree, signal, callback);
-    });
-    break;
-  }
+    killAll(pids, signal, callback)
+  })
 };
 
 function killAll (tree, signal, callback) {
@@ -73,45 +46,4 @@ function killPid(pid, signal) {
     if (err.code !== 'ESRCH')
       console.error(err);
   }
-}
-
-function buildProcessTree (parentPid, tree, pidsToProcess, spawnChildProcessesList, cb) {
-  var ps = spawnChildProcessesList(parentPid);
-  var allData = '';
-
-  ps.on('error', function(err) {
-    console.error(err);
-  });
-
-  if (ps.stdout) {
-    ps.stdout.on('data', function (data) {
-      data = data.toString('ascii');
-      allData += data;
-    });
-  }
-
-  var onClose = function (code) {
-    delete pidsToProcess[parentPid];
-
-    if (code !== 0) {
-      // no more parent processes
-      if (Object.keys(pidsToProcess).length == 0) {
-        cb();
-      }
-      return;
-    }
-    var pids = allData.match(/\d+/g) || [];
-    if (pids.length === 0)
-      return cb();
-
-    pids.forEach(function (pid) {
-      pid = parseInt(pid, 10);
-      tree[parentPid].push(pid);
-      tree[pid] = [];
-      pidsToProcess[pid] = 1;
-      buildProcessTree(pid, tree, pidsToProcess, spawnChildProcessesList, cb);
-    });
-  };
-
-  ps.on('close', onClose);
 }

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "moment": "^2.19",
     "needle": "^2.2.0",
     "nssocket": "0.6.0",
+    "pidtree": "^0.2.0",
     "pidusage": "^2.0.5",
     "pm2-axon": "3.1.0",
     "pm2-axon-rpc": "0.5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |  na
| License       | MIT

Don't merge this for now.

Attempt to improve treekill performances (the `pstree` module could be used to get a child process monitoring on pm2 see this 2 years wanted feature https://github.com/Unitech/pm2/issues/1869). 
@simonepri has worked on the best way to get a tree of a given PID. He has found out that ps was faster then `pgrep`. Let's see how the test suite runs for now.