### PR TITLE
disable autorestart on clean exit

### DIFF
--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -157,6 +157,12 @@
     "docDefault": "True",
     "docDescription": "Enable or disable auto restart after process failure"
   },
+  "no_autorestart_on_clean_exit": {
+    "type": "boolean",
+    "default" : false,
+    "docDefault": "False",
+    "docDescription": "Disable auto restart when process exits with exit code 0"
+  },
   "watch": {
     "type": [
       "boolean",

--- a/lib/God.js
+++ b/lib/God.js
@@ -293,9 +293,9 @@ God.handleExit = function handleExit(clu, exit_code, kill_signal) {
 
   var stopping    = (proc.pm2_env.status == cst.STOPPING_STATUS
                      || proc.pm2_env.status == cst.STOPPED_STATUS
-                     || proc.pm2_env.status == cst.ERRORED_STATUS) || (proc.pm2_env.autorestart === false ||
-                                                                       proc.pm2_env.autorestart === "false");
-
+                     || proc.pm2_env.status == cst.ERRORED_STATUS) 
+                     || (proc.pm2_env.autorestart === false || proc.pm2_env.autorestart === "false")
+                     || (proc.pm2_env.no_autorestart_on_clean_exit === true && exit_code === 0)
   var overlimit   = false;
 
   if (stopping) proc.process.pid = 0;


### PR DESCRIPTION
Please always submit pull requests on the development branch.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #3595
| License       | MIT
| Doc PR        | In progress

This is an attempt to fix #3595.
If the option `no_autorestart_on_clean_exit`  is set to true and the process exited with exit code '0', don't restart the app.

But, I can't get this to work everytime. The value of `proc.pm2_env.no_autorestart_on_clean_exit` is sometimes true and sometimes false. Can someone guide me on this?
