### PR TITLE
OpenBSD init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,14 +228,14 @@ $ pm2 reloadLogs          # Reload all logs
 
 PM2 can generates and configure a startup script to keep PM2 and your processes alive at every server restart.
 
-Supports init systems like: **systemd** (Ubuntu 16, CentOS, Arch), **upstart** (Ubuntu 14/12), **launchd** (MacOSx, Darwin), **rc.d** (FreeBSD).
+Supports init systems like: **systemd** (Ubuntu 16, CentOS, Arch), **upstart** (Ubuntu 14/12), **launchd** (MacOSx, Darwin), **rc.d** (FreeBSD, OpenBSD).
 
 ```bash
 # Auto detect init system + generate and setup PM2 boot at server startup
 $ pm2 startup
 
 # Manually specify the startup system
-# Can be: systemd, upstart, launchd, rcd
+# Can be: systemd, upstart, launchd, rcd, rcd-openbsd
 $ pm2 startup [platform]
 
 # Disable and remove PM2 boot at server startup

--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -41,7 +41,8 @@ module.exports = function(CLI) {
       'chkconfig'  : 'systemv',
       'rc-update'  : 'openrc',
       'launchctl'  : 'launchd',
-      'sysrc'      : 'rcd'
+      'sysrc'      : 'rcd',
+      'rcctl'      : 'rcd-openbsd',
     };
     var init_systems = Object.keys(hash_map);
 
@@ -147,6 +148,16 @@ module.exports = function(CLI) {
         'sysrc -x ' + service_name  + '_enable',
         'rm /usr/local/etc/rc.d/' + service_name
       ];
+      break;
+    case 'rcd-openbsd':
+      service_name = (opts.serviceName || 'pm2_' + user);
+      var destination = path.join('/etc/rc.d', service_name);
+      commands = [
+        'rcctl stop ' + service_name,
+        'rcctl disable ' + service_name,
+        'rm ' + destination
+      ];
+      break;
     };
 
     require('shelljs').exec(commands.join('&& '), function(code, stdout, stderr) {
@@ -268,6 +279,17 @@ module.exports = function(CLI) {
       commands = [
         'chmod 755 ' + destination,
         'sysrc ' + service_name + '_enable=YES'
+      ];
+      break;
+    case 'openbsd':
+    case 'rcd-openbsd':
+      template = getTemplate('rcd-openbsd');
+      service_name = (opts.serviceName || 'pm2_' + user);
+      destination = path.join('/etc/rc.d/', service_name);
+      commands = [
+        'chmod 755 ' + destination,
+        'rcctl enable ' + service_name,
+        'rcctl start ' + service_name
       ];
       break;
     case 'openrc':

--- a/lib/templates/init-scripts/rcd-openbsd.tpl
+++ b/lib/templates/init-scripts/rcd-openbsd.tpl
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# from /usr/ports/infrastructure/templates/rc.template
+
+daemon="/usr/local/bin/pm2"
+#daemon_flags=
+#daemon_rtable=0
+#daemon_timeout="30"
+daemon_user="%USER%"
+
+. /etc/rc.d/rc.subr
+
+pexp="node: PM2.*God Daemon.*"
+#rc_bg= # (undefined)
+#rc_reload= # (undefined)
+#rc_usercheck=YES
+
+#rc_pre() {
+#}
+
+rc_start() {
+	${rcexec} "${daemon} ${daemon_flags} resurrect"
+}
+
+#rc_check() {
+#	pgrep -T "${daemon_rtable}" -q -xf "${pexp}"
+#}
+
+rc_reload() {
+	${rcexec} "${daemon} reload all"
+	#pkill -HUP -T "${daemon_rtable}" -xf "${pexp}"
+}
+
+#rc_stop() {
+#	pkill -T "${daemon_rtable}" -xf "${pexp}"
+#}
+
+#rc_post() {
+#}
+
+rc_cmd $1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
This adds support for OpenBSD-style rc.d init scripts, which differ significantly from FreeBSD-style rc.d init scripts.