### PR TITLE
Add new feature  with unstable restart

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -325,30 +325,45 @@ God.handleExit = function handleExit(clu, exit_code, kill_signal) {
   var min_uptime = typeof(proc.pm2_env.min_uptime) !== 'undefined' ? proc.pm2_env.min_uptime : 1000;
   var max_restarts = typeof(proc.pm2_env.max_restarts) !== 'undefined' ? proc.pm2_env.max_restarts : 16;
 
+
+  //Only if process restart in repiting restart count ++ if process not run minimal uptime
+  if ((Date.now() - proc.pm2_env.pm_uptime) < min_uptime) {
+    // Increment unstable restart
+    proc.pm2_env.repiting_reset += 1;
+  } else {
+    proc.pm2_env.repiting_reset = 0;
+  }
+
+
+
+  //On boot
   if ((Date.now() - proc.pm2_env.created_at) < (min_uptime * max_restarts)) {
     if ((Date.now() - proc.pm2_env.pm_uptime) < min_uptime) {
       // Increment unstable restart
       proc.pm2_env.unstable_restarts += 1;
+    } else {
+      proc.pm2_env.repiting_reset = 0;
     }
+  }
 
-    if (proc.pm2_env.unstable_restarts >= max_restarts) {
-      // Too many unstable restart in less than 15 seconds
-      // Set the process as 'ERRORED'
-      // And stop restarting it
-      proc.pm2_env.status = cst.ERRORED_STATUS;
-      proc.process.pid = 0;
 
-      console.log('Script %s had too many unstable restarts (%d). Stopped. %j',
-                  proc.pm2_env.pm_exec_path,
-                  proc.pm2_env.unstable_restarts,
-                  proc.pm2_env.status);
+  if (proc.pm2_env.unstable_restarts >= max_restarts || proc.pm2_env.repiting_reset>= max_restarts) {
+    // Too many unstable restart in less than 15 seconds
+    // Set the process as 'ERRORED'
+    // And stop restarting it
+    proc.pm2_env.status = cst.ERRORED_STATUS;
+    proc.process.pid = 0;
 
-      God.notify('restart overlimit', proc);
+    console.log('Script %s had too many unstable restarts (%d). Stopped. %j',
+      proc.pm2_env.pm_exec_path,
+      proc.pm2_env.unstable_restarts,
+      proc.pm2_env.status);
 
-      proc.pm2_env.unstable_restarts = 0;
-      proc.pm2_env.created_at = null;
-      overlimit = true;
-    }
+    God.notify('restart overlimit', proc);
+
+    proc.pm2_env.unstable_restarts = 0;
+    proc.pm2_env.created_at = null;
+    overlimit = true;
   }
 
   if (typeof(exit_code) !== 'undefined') proc.pm2_env.exit_code = exit_code;

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -355,6 +355,7 @@ module.exports = function(God) {
     God.clusters_db[id].pm2_env.created_at = Utility.getDate();
     God.clusters_db[id].pm2_env.unstable_restarts = 0;
     God.clusters_db[id].pm2_env.restart_time = 0;
+    God.clusters_db[id].pm2_env.repiting_reset = 0;
 
     return cb(null, God.getFormatedProcesses());
   };


### PR DESCRIPTION
After my process has started and worked for a while, it can start reloading (e.g. because of data base connecting error) and the system will not stop it after n reloadings noted in settings. These changes fix this problem.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT