### PR TITLE
Improve upstart.tpl shell script syntax

### DIFF
--- a/lib/templates/init-scripts/upstart.tpl
+++ b/lib/templates/init-scripts/upstart.tpl
@@ -24,7 +24,7 @@ MAX_OPEN_FILES=
 
 # overwrite settings from default file
 if [ -f "$DEFAULT" ]; then
-	  . "$DEFAULT"
+    . "$DEFAULT"
 fi
 
 # set maximum open files if set
@@ -33,7 +33,8 @@ if [ -n "$MAX_OPEN_FILES" ]; then
 fi
 
 get_user_shell() {
-    local shell=$(getent passwd ${1:-`whoami`} | cut -d: -f7 | sed -e 's/[[:space:]]*$//')
+    local shell
+    shell=$(getent passwd "${1:-$(whoami)}" | cut -d: -f7 | sed -e 's/[[:space:]]*$//')
 
     if [[ $shell == *"/sbin/nologin" ]] || [[ $shell == "/bin/false" ]] || [[ -z "$shell" ]];
     then
@@ -44,8 +45,9 @@ get_user_shell() {
 }
 
 super() {
-    local shell=$(get_user_shell $USER)
-    su - $USER -s $shell -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
+    local shell
+    shell=$(get_user_shell $USER)
+    su - "$USER" -s "$shell" -c "PATH=$PATH; PM2_HOME=$PM2_HOME $*"
 }
 
 start() {


### PR DESCRIPTION
This pull request improves `upstart.tpl` shell script syntax including:    
```
    - Use spaces instead of tab for indent
    - Replace deprecated `command` with $(command)
    - Add missing quote to variable reference
    - Separate variable declaration and assign to avoid masking return values
```

This is my first pull request to `pm2`, please let me know if there is anything I missed that should be fixed, many thanks!

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT