### PR TITLE
Pidusage@^2.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "moment": "^2.22.2",
     "needle": "^2.2.1",
     "nssocket": "0.6.0",
-    "pidusage": "2.0.13",
+    "pidusage": "^2.0.14",
     "pm2-axon": "3.3.0",
     "pm2-axon-rpc": "^0.5.1",
     "pm2-deploy": "^0.3.9",


### PR DESCRIPTION
revert https://github.com/Unitech/pm2/pull/3826 to keep the bug fix for node < 4.5

note that the buggy pidusage version has been unpublished and I'm very sorry it got published without me wanting to, it caused a 3h gap where pm2 installations may have break.