### PR TITLE
fix: #3831 switch registerToKM() to register()

### DIFF
--- a/lib/API/pm2-plus/process-selector.js
+++ b/lib/API/pm2-plus/process-selector.js
@@ -18,7 +18,7 @@ module.exports = function(CLI) {
       try {
         fs.statSync(this._conf.INTERACTION_CONF);
       } catch(e) {
-        return this.registerToKM();
+        return this.register({});
       }
     }
 


### PR DESCRIPTION
Use register() method to avoid exception.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3831
| License       | MIT