### PR TITLE
fix: #3786 fix issue when triggering an action that does not exist

### DIFF
--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -801,17 +801,11 @@ module.exports = function(God) {
 
         var proc_env = God.clusters_db[id].pm2_env;
 
-        var action_exist = false;
-        proc_env.axm_actions.forEach(function(action) {
-          console.log(action, cmd)
-          if (action.action_name === cmd.msg) {
-            action_exist = true;
-          }
-        });
+        const isActionAvailable = proc_env.axm_actions.find(action => action.action_name === cmd.msg) !== undefined
 
         // if action doesn't exist for this app
         // try with the next one
-        if (action_exist === false) {
+        if (isActionAvailable === false) {
           arr.shift();
           return ex(arr);
         }

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -801,6 +801,22 @@ module.exports = function(God) {
 
         var proc_env = God.clusters_db[id].pm2_env;
 
+        var action_exist = false;
+        proc_env.axm_actions.forEach(function(action) {
+          console.log(action, cmd)
+          if (action.action_name === cmd.msg) {
+            action_exist = true;
+          }
+        });
+
+        // if action doesn't exist for this app
+        // try with the next one
+        if (action_exist === false) {
+          arr.shift();
+          return ex(arr);
+        }
+
+
         if ((p.basename(proc_env.pm_exec_path) == name ||
              proc_env.name == name) &&
             (proc_env.status == cst.ONLINE_STATUS ||


### PR DESCRIPTION
If action doesn't exist we should display an error, even if we trigger action by application's name.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3786
| License       | MIT