### PR TITLE
fix: #3865

### DIFF
--- a/lib/Daemon.js
+++ b/lib/Daemon.js
@@ -331,6 +331,12 @@ Daemon.prototype.sendReady = function(cb) {
 Daemon.prototype.gracefullExit = function() {
   var that = this;
 
+  // never execute multiple gracefullExit simultaneously
+  // this can lead to loss of some apps in dump file
+  if (this.isExiting) return
+
+  this.isExiting = true
+
   God.bus.emit('pm2:kill', {
     status : 'killed',
     msg    : 'pm2 has been killed by SIGNAL'
@@ -352,6 +358,7 @@ Daemon.prototype.gracefullExit = function() {
         fs.unlinkSync(that.pid_path);
       } catch(e) {}
       setTimeout(function() {
+        that.isExiting = false
         console.log('Exited peacefully');
         process.exit(cst.SUCCESS_EXIT);
       }, 2);


### PR DESCRIPTION
Ensure pm2 never run simultaneous gracefullExit, prevent dump file corruption !

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3865 
| License       | MIT