### PR TITLE
fix: remove warn message about clustering for old node 0.10 version

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -731,13 +731,6 @@ function checkExecMode(conf) {
 
   if (conf.instances && conf.exec_mode === undefined)
     conf.exec_mode = 'cluster_mode';
-
-  // Tell user about unstability of cluster module + Roadmap
-  if (/^cluster(_mode)?$/i.test(conf.exec_mode) &&
-      process.version.match(/0.10/) &&
-      !process.env.TRAVIS) {
-    warn('You should not use the cluster_mode (-i) in production, it\'s still a beta feature. A front HTTP load balancer or interaction with NGINX will be developed in the future.');
-  }
 }
 
 /**


### PR DESCRIPTION
Remove unused message about clustering.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3910
| License       | MIT
