### PR TITLE
fix: #3896 update file path if we are reading the backup file

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -484,7 +484,7 @@ module.exports = function(CLI) {
     var processes;
 
     function readDumpFile(dumpFilePath) {
-      Common.printOut(cst.PREFIX_MSG + 'Restoring processes located in %s', cst.DUMP_FILE_PATH);
+      Common.printOut(cst.PREFIX_MSG + 'Restoring processes located in %s', dumpFilePath);
       try {
         var apps = fs.readFileSync(dumpFilePath);
       } catch (e) {


### PR DESCRIPTION
Be sure to display backup file's path in warning message.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3896
| License       | MIT
