### PR TITLE
 Handle path spaces on Windows

### DIFF
--- a/lib/API/Modules/NPM.js
+++ b/lib/API/Modules/NPM.js
@@ -180,7 +180,7 @@ function continueInstall(CLI, module_name, opts, cb) {
   require('mkdirp')(install_path, function() {
     process.chdir(os.homedir());
 
-    var install_instance = spawn(cst.IS_WINDOWS ? 'npm.cmd' : 'npm', ['install', module_name, '--loglevel=error', '--prefix', install_path ], {
+    var install_instance = spawn(cst.IS_WINDOWS ? 'npm.cmd' : 'npm', ['install', module_name, '--loglevel=error', '--prefix', '"'+install_path+'"' ], {
       stdio : 'inherit',
       env: process.env,
 		  shell : true


### PR DESCRIPTION
Can't install modules on Windows when pm2 has spaces in path, i.e. "Program Files".

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT