### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Or go to the application and create an account:
 
 ### PM2 Plus: Expose Custom Metrics
 
-To get more insights on how your application behave, plug custom metrics inside your code and monitor them with the `pm2 monit` command:
+To get more insights on how your application behaves, plug custom metrics inside your code and monitor them with the `pm2 monit` command:
 
 In your project install [pm2-io-pm](https://github.com/keymetrics/pm2-io-apm):
 


### PR DESCRIPTION
Spelling mistake fixed.

"how your application behave" vs "how your application behaves"

The typo is caused by an assumption of plurality of "application".

Decided to fix this to singular as the same wording is used across this readme.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT