### PR TITLE
Auto restart god

### DIFF
--- a/lib/templates/init-scripts/systemd-online.tpl
+++ b/lib/templates/init-scripts/systemd-online.tpl
@@ -13,6 +13,7 @@ LimitCORE=infinity
 Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=PM2_HOME=%HOME_PATH%
 PIDFile=%HOME_PATH%/pm2.pid
+Restart=on-failure
 
 ExecStart=%PM2_PATH% resurrect
 ExecReload=%PM2_PATH% reload all

--- a/lib/templates/init-scripts/systemd.tpl
+++ b/lib/templates/init-scripts/systemd.tpl
@@ -12,6 +12,7 @@ LimitCORE=infinity
 Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=PM2_HOME=%HOME_PATH%
 PIDFile=%HOME_PATH%/pm2.pid
+Restart=on-failure
 
 ExecStart=%PM2_PATH% resurrect
 ExecReload=%PM2_PATH% reload all

--- a/packager/build-deb-rpm.sh
+++ b/packager/build-deb-rpm.sh
@@ -83,6 +83,7 @@ LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 PIDFile=/etc/pm2/pm2.pid
+Restart=on-failure
 
 ExecStart=/usr/bin/pm2 resurrect
 ExecReload=/usr/bin/pm2 reload all

--- a/packager/debian/control
+++ b/packager/debian/control
@@ -1,6 +1,6 @@
 Package: pm2
 Version: __VERSION__
-Depends: nodejs (>= 6.12.2)
+Depends: nodejs (>= 6.3.0)
 Conflicts: nodejs (<< 0.12.0)
 Section: devel
 Priority: optional


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls


updates the systemd template files to auto-restart the god daemon should it somehow crash.

you can test with `sudo kill -9 <pid of god daemon>`

pm2 doesn't restart itself! even after `pm2 startup`.

this fixes that.

(also, I accidentally included a commit where I reduced the .deb packages node dep from 6.12.3 down to 6.3.0 -- that's not required for this MR, but it does help me as I've got a lot of servers w/ 6.3.0 installed...)