### PR TITLE
fix mode output in UX.dispAsTable

### DIFF
--- a/lib/API/CliUx.js
+++ b/lib/API/CliUx.js
@@ -269,7 +269,6 @@ UX.dispAsTable = function(list, commander) {
   list.forEach(function(l) {
     var obj = {};
 
-    var mode = l.pm2_env.exec_mode;
     var status = l.pm2_env.status;
     var key = l.pm2_env.name || p.basename(l.pm2_env.pm_exec_path.script);
     key = chalk.bold.cyan(key);
@@ -331,7 +330,7 @@ UX.dispAsTable = function(list, commander) {
       obj[key].push(l.pm2_env.version);
 
       // Exec mode
-      obj[key].push(mode == 'fork_mode' ? chalk.inverse.bold('fork') : chalk.blue.bold('cluster'));
+      obj[key].push(l.pm2_env.exec_mode.split('_')[0] === 'fork' ? chalk.inverse.bold('fork') : chalk.blue.bold('cluster'));
 
       // PID
       if (!stacked)


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->

I do not know why, but after restart with ecosystem file `exec_mode` changed from `fork_mode` to `fork`, I tried figure out where this happens, but was not successful. In any case `fork` is alias for `fork_mode`, and bug still exists in `lib/API/CliUx.js`.