### PR TITLE
Fix log tail for combined log

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -179,6 +179,12 @@ module.exports = function(CLI) {
               app_name : proc.pm2_env.pm_id + '|' + proc.pm2_env.name,
               type     : 'err'
             });
+          if (proc.pm2_env.pm_log_path && !exclusive)
+            pushIfUnique({
+              path     : proc.pm2_env.pm_log_path,
+              app_name : proc.pm2_env.pm_id + '|' + proc.pm2_env.name,
+              type     : 'out'
+            });
         }
         // Populate the array `files_list` with the paths of all files we need to tail, when log in put is a regex
         else if(proc.pm2_env && (isNaN(id) && id[0] === '/' && id[id.length - 1] === '/')) {


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -
<!--
*Please update this template with something that matches your PR*
-->

If set `out` and `err` logs as `/dev/null` and send everything to combined logs then when user call `pm2 logs` last lines will not be shown.
This is not best solution, because lines can overlap themself. Any ideas?