### PR TITLE
pm2 should ignore -s, --silent, -v after '--'

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -19,13 +19,16 @@ var PM2          = require('../lib/API.js');
 var pkg          = require('../package.json');
 var tabtab       = require('../lib/completion.js');
 
+// pm2 should ignore -s --silent -v if they are after '--'
+var variadicArgsDashesPos = process.argv.indexOf('--');
+
 // Early detection of silent to avoid printing motd
-if (process.argv.indexOf('--silent') > -1 ||
-    process.argv.indexOf('-s') > -1) {
+if (process.argv.indexOf('--silent') > -1 && process.argv.indexOf('--silent') < variadicArgsDashesPos ||
+    process.argv.indexOf('-s') > -1 && process.argv.indexOf('-s') < variadicArgsDashesPos) {
   process.env.PM2_DISCRETE_MODE = true;
 }
 
-if (process.argv.indexOf('-v') > -1) {
+if (process.argv.indexOf('-v') > -1 && process.argv.indexOf('-v') < variadicArgsDashesPos) {
   console.log(pkg.version);
   process.exit(0);
 }


### PR DESCRIPTION
pm2 should ignore -s --silent -v if they are after '--' (variadic args for start and restart commands)
Example:
pm2 start node-red --node-args="--max-old-space-size=128" -- -v
Currently just prints versions and exits.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->