### PR TITLE
Ensure node_args are not removed on restart

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -106,6 +106,10 @@ Common.prepareAppConf = function(opts, app) {
     app.node_args = [];
   }
 
+  if (app.port && app.env) {
+    app.env.PORT = app.port;
+  }
+
   // CWD option resolving
   cwd && (cwd[0] != '/') && (cwd = path.resolve(process.cwd(), cwd));
   cwd = cwd || opts.cwd;
@@ -468,7 +472,7 @@ Common.safeExtend = function(origin, add){
   if (!add || typeof add != 'object') return origin;
 
   //Ignore PM2's set environment variables from the nested env
-  var keysToIgnore = ['name', 'exec_mode', 'env', 'args', 'pm_cwd', 'exec_interpreter', 'pm_exec_path', 'node_args', 'pm_out_log_path', 'pm_err_log_path', 'pm_pid_path', 'pm_id', 'status', 'pm_uptime', 'created_at', 'unstable_restarts', 'restart_time', 'axm_actions', 'pmx_module', 'command', 'watch', 'versioning', 'vizion_runing', 'MODULE_DEBUG', 'pmx', 'axm_options', 'created_at', 'watch', 'vizion', 'axm_dynamic', 'axm_monitor', 'instances', 'automation', 'autorestart', 'node_args', 'unstable_restart', 'treekill', 'exit_code', 'vizion'];
+  var keysToIgnore = ['name', 'exec_mode', 'env', 'args', 'pm_cwd', 'exec_interpreter', 'pm_exec_path', 'node_args', 'pm_out_log_path', 'pm_err_log_path', 'pm_pid_path', 'pm_id', 'status', 'pm_uptime', 'created_at', 'unstable_restarts', 'restart_time', 'axm_actions', 'pmx_module', 'command', 'watch', 'versioning', 'vizion_runing', 'MODULE_DEBUG', 'pmx', 'axm_options', 'created_at', 'watch', 'vizion', 'axm_dynamic', 'axm_monitor', 'instances', 'automation', 'autorestart', 'unstable_restart', 'treekill', 'exit_code', 'vizion'];
 
   var keys = Object.keys(add);
   var i = keys.length;
@@ -702,14 +706,6 @@ Common.verifyConfs = function(appConfs) {
         !app.instances &&
         typeof(app.merge_logs) == 'undefined') {
       app.merge_logs = true;
-    }
-
-    if (!app.node_args) {
-      app.node_args = [];
-    }
-
-    if (app.port && app.env) {
-      app.env.PORT = app.port;
     }
 
     var ret;

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -102,6 +102,10 @@ Common.prepareAppConf = function(opts, app) {
     process.env.PWD = app.cwd;
   }
 
+  if (!app.node_args) {
+    app.node_args = [];
+  }
+
   // CWD option resolving
   cwd && (cwd[0] != '/') && (cwd = path.resolve(process.cwd(), cwd));
   cwd = cwd || opts.cwd;


### PR DESCRIPTION
This overwrites args when restarting

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes
| Fixed tickets | #4029
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->