### PR TITLE
Fix flush [api] incorrect behavior and log message

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -17,41 +17,49 @@ module.exports = function(CLI) {
    */
   CLI.prototype.flush = function(api, cb) {
     var that = this;
-    Common.printOut(cst.PREFIX_MSG + 'Flushing ' + cst.PM2_LOG_FILE_PATH);
-    fs.closeSync(fs.openSync(cst.PM2_LOG_FILE_PATH, 'w'));
 
     that.Client.executeRemote('getMonitorData', {}, function(err, list) {
       if (err) {
         Common.printError(err);
         return cb ? cb(Common.retErr(err)) : that.exitCli(cst.ERROR_EXIT);
       }
-      list.forEach(function(l) {
+
+      function flushLog(app) {
         Common.printOut(cst.PREFIX_MSG + 'Flushing');
-        Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
-        Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
-
-        if(typeof api == 'undefined')
-        {
-          if (l.pm2_env.pm_log_path) {
-            Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_log_path);
-            fs.closeSync(fs.openSync(l.pm2_env.pm_log_path, 'w'));
-          }
-          fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
-          fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
+      
+        if (app.pm2_env.pm_log_path) {
+          Common.printOut(cst.PREFIX_MSG + app.pm2_env.pm_log_path);
+          fs.closeSync(fs.openSync(app.pm2_env.pm_log_path, 'w'));
         }
-        else
-        {
-          if (l.pm2_env.pm_log_path && l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(api)) {
-            Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_log_path);
-            fs.closeSync(fs.openSync(l.pm2_env.pm_log_path, 'w'));
-          }
 
-          if(l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api))
-            fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
-          if(l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(api))
-            fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
+        Common.printOut(cst.PREFIX_MSG + app.pm2_env.pm_out_log_path);
+        fs.closeSync(fs.openSync(app.pm2_env.pm_out_log_path, 'w'));
+
+        Common.printOut(cst.PREFIX_MSG + app.pm2_env.pm_err_log_path);
+        fs.closeSync(fs.openSync(app.pm2_env.pm_err_log_path, 'w'));
+      }
+
+      if (typeof api === 'undefined') {
+        Common.printOut(cst.PREFIX_MSG + 'Flushing ' + cst.PM2_LOG_FILE_PATH);
+        fs.closeSync(fs.openSync(cst.PM2_LOG_FILE_PATH, 'w'));  
+
+        list.forEach(function(l) {
+          flushLog(l);
+        });
+      } else {
+        var app = list.find(function(l) {
+          return (l.pm_id === Number(api) || l.name === api);
+        });
+
+        if (app) {
+          flushLog(app);
+        } else {
+          var notFoundErr = Error(cst.PREFIX_MSG + 'Failed to find app with name or id matching ' + api); 
+          Common.printError(notFoundErr);
+          return cb ? cb(Common.retErr(notFoundErr)) : that.exitCli(cst.ERROR_EXIT);
         }
-      });
+      }
+
       Common.printOut(cst.PREFIX_MSG + 'Logs flushed');
       return cb ? cb(null, list) : that.exitCli(cst.SUCCESS_EXIT);
     });

--- a/test/programmatic/flush.mocha.js
+++ b/test/programmatic/flush.mocha.js
@@ -50,6 +50,7 @@ describe('Programmatic flush feature test', function() {
     });
     it('flush only echo logs', function(done) {
       pm2.start({
+        name: 'echo',
         script: './echo.js',
         error_file : 'error-echo.log',
         out_file   : 'out-echo.log',


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pull/151
<!--
*Please update this template with something that matches your PR*
-->

Made the following changes to the `flush [api]` command:
- Matches input argument by app name/id instead of log filename
- Errors out if no matching app is found
- Avoids flushing the shared `PM2_LOG_FILE_PATH` as it contains logs for other apps as well
- Avoids wrongly printing 'Flushing ...' for other (non-matched) apps