### PR TITLE
fix: check exec_mode in all cases

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -167,6 +167,9 @@ Common.prepareAppConf = function(opts, app) {
   // Interpreter
   Common.sink.resolveInterpreter(app);
 
+  // Exec mode and cluster stuff
+  Common.sink.determineExecMode(app);
+
   /**
    * Scary
    */
@@ -563,6 +566,7 @@ Common.resolveAppAttributes = function(opts, legacy_app) {
  * @returns {Array}
  */
 Common.verifyConfs = function(appConfs) {
+  console.log('VERIFY CONFS')
   if (!appConfs || appConfs.length == 0) {
     return [];
   }

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -566,7 +566,6 @@ Common.resolveAppAttributes = function(opts, legacy_app) {
  * @returns {Array}
  */
 Common.verifyConfs = function(appConfs) {
-  console.log('VERIFY CONFS')
   if (!appConfs || appConfs.length == 0) {
     return [];
   }

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -167,9 +167,6 @@ Common.prepareAppConf = function(opts, app) {
   // Interpreter
   Common.sink.resolveInterpreter(app);
 
-  // Exec mode and cluster stuff
-  Common.sink.determineExecMode(app);
-
   /**
    * Scary
    */
@@ -577,6 +574,9 @@ Common.verifyConfs = function(appConfs) {
 
   for (var i = 0; i < appConfs.length; i++) {
     var app = appConfs[i];
+
+    // Exec mode and cluster stuff
+    Common.sink.determineExecMode(app);
 
     // JSON conf: alias cmd to script
     if (app.cmd && !app.script) {

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -578,8 +578,8 @@ Common.verifyConfs = function(appConfs) {
   for (var i = 0; i < appConfs.length; i++) {
     var app = appConfs[i];
 
-    // Exec mode and cluster stuff
-    Common.sink.determineExecMode(app);
+    if (app.exec_mode)
+      app.exec_mode = app.exec_mode.replace(/^(fork|cluster)$/, '$1_mode');
 
     // JSON conf: alias cmd to script
     if (app.cmd && !app.script) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3946 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

Now check exec mode in all cases and switch automatically to *_mode instead of *