### PR TITLE
fix: limit concurrent_actions to 1 if nb process <= 2

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -1262,6 +1262,9 @@ class API {
     function processIds(ids, cb) {
       Common.printOut(conf.PREFIX_MSG + 'Applying action %s on app [%s](ids: %s)', action_name, process_name, ids);
 
+      if (ids.length <= 2)
+        concurrent_actions = 1;
+
       if (action_name == 'deleteProcessId')
         concurrent_actions = 10;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3143 #4047
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

