### PR TITLE
docs: updated license file to GitHub standard

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,0 @@
-GNU-AGPL-3.0.txt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,7 @@
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -630,12 +629,12 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    PM2 Process manager for Node.JS
-    Copyright (C) 2013-2016 Strzelewicz Alexandre
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -644,7 +643,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -659,7 +658,4 @@ specific requirements.
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
-<http://www.gnu.org/licenses/>.
-
-
---- ALEXANDRE STRZELEWICZ
+<https://www.gnu.org/licenses/>.


### PR DESCRIPTION
This has a significant benefit, because now GitHub will properly flag the project as AGPL licensed, and it will also provide a short summary to potential users what that means in terms of rights and obligations.

See license file of other project and see the contrast: 
https://github.com/ASTex-ICube/ASTex/blob/master/LICENSE.txt

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | GNU-AGPL 3.0 (or, Copyright (C) 2007 Free Software Foundation, since it's their license)