### PR TITLE
fix: trigger scoped actions

### DIFF
--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -763,7 +763,7 @@ module.exports = function(God) {
         /*
          * Send message
          */
-        if (cmd.opts == null)
+        if (cmd.opts == null && !cmd.uuid)
           proc.send(cmd.msg);
         else
           proc.send(cmd);


### PR DESCRIPTION
Scoped actions require a uuid field to work, so we should make sure to send it to the child process. Currently, we only send the action name if `opts` are not defined.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 