### PR TITLE
fix spawn ps ENOENT

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -11,6 +11,7 @@ var eachLimit    = require('async/eachLimit');
 var exec         = require('child_process').exec;
 var Common       = require('../Common.js');
 var cst          = require('../../constants.js');
+var util 	       = require('util');
 
 module.exports = function(CLI) {
   /**
@@ -307,8 +308,11 @@ module.exports = function(CLI) {
     /**
      * 4# Replace template variable value
      */
+   var envPath = new RegExp(path.dirname(process.execPath)).test(process.env.PATH)
+      ? process.env.PATH
+      : util.format('%s:%s', process.env.PATH || '', path.dirname(process.execPath));
     template = template.replace(/%PM2_PATH%/g, process.mainModule.filename)
-      .replace(/%NODE_PATH%/g, path.dirname(process.execPath))
+      .replace(/%NODE_PATH%/g, envPath)
       .replace(/%USER%/g, user)
       .replace(/%HOME_PATH%/g, opts.hp ? path.resolve(opts.hp, '.pm2') : cst.PM2_ROOT_PATH)
       .replace(/%SERVICE_NAME%/g, service_name);


### PR DESCRIPTION
The `process.env.PATH`  is not set in the PATH of plist. And the pm2 will throw command ENOENT error because of it.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3879
| License       | MIT

<!--
*Please update this template with something that matches your PR*
-->