### PR TITLE
Added Restart and RestartSec into the systemd script

### DIFF
--- a/lib/templates/init-scripts/systemd.tpl
+++ b/lib/templates/init-scripts/systemd.tpl
@@ -12,6 +12,8 @@ LimitCORE=infinity
 Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=PM2_HOME=%HOME_PATH%
 PIDFile=%HOME_PATH%/pm2.pid
+Restart=always
+RestartSec=30
 
 ExecStart=%PM2_PATH% resurrect
 ExecReload=%PM2_PATH% reload all


### PR DESCRIPTION
When Ubuntu's out of memory killer kills PM2 it never restarts. Adding these lines should restart it after 30 seconds.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4150 
| License       | MIT