### PR TITLE
Fix for missing column title

### DIFF
--- a/lib/API/CliUx.js
+++ b/lib/API/CliUx.js
@@ -209,7 +209,7 @@ UX.describeTable = function(process) {
  */
 UX.dispAsTable = function(list, commander) {
   var stacked = (process.stdout.columns || 90) < 90;
-  var app_head = stacked ? ['Name', 'id', 'mode', 'status', '↺', 'cpu', 'memory'] :
+  var app_head = stacked ? ['Name', 'id', 'version', 'mode', 'status', '↺', 'cpu', 'memory'] :
       ['App name', 'id', 'version', 'mode', 'pid', 'status', 'restart', 'uptime', 'cpu', 'mem', 'user', 'watching'];
   var mod_head = stacked ? ['Module', 'id', 'status', 'cpu', 'mem'] :
       ['Module', 'id', 'version', 'pid',  'status', 'restart', 'cpu', 'memory', 'user'];


### PR DESCRIPTION
Table list didn't have *version* column title, that caused a shift of other column titles.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4021
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->