### PR TITLE
fix pm2 unstartup fialed in macos

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -137,7 +137,7 @@ module.exports = function(CLI) {
     case 'launchd':
       var destination = path.join(process.env.HOME, 'Library/LaunchAgents/' + launchd_service_name + '.plist');
       commands = [
-        'launchctl remove ' + launchd_service_name,
+        'launchctl remove ' + launchd_service_name + ' || true',
         'rm ' + destination
       ];
       break;


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3732 , #1349 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->


The `pm2 unstartup` will always failed in macos. Because the pm2.*.plist will never been deleted.

```
commands = [
        'launchctl remove ' + launchd_service_name + ' || true',
        'rm ' + destination
      ];
```
`launchctl remove` always return no-zero value, so `rm` in the next will never been executed.
