### PR TITLE
Fix help message of describe/env command

### DIFF
--- a/bin/pm2
+++ b/bin/pm2
@@ -726,34 +726,34 @@ commander.command('reset <name|id|all>')
     pm2.reset(proc_id);
   });
 
-commander.command('describe <id>')
-  .description('describe all parameters of a process id')
+commander.command('describe <name|id>')
+  .description('describe all parameters of a process')
   .action(function(proc_id) {
     pm2.describe(proc_id);
   });
 
-commander.command('desc <id>')
-  .description('(alias) describe all parameters of a process id')
+commander.command('desc <name|id>')
+  .description('(alias) describe all parameters of a process')
   .action(function(proc_id) {
     pm2.describe(proc_id);
   });
 
-commander.command('info <id>')
-  .description('(alias) describe all parameters of a process id')
+commander.command('info <name|id>')
+  .description('(alias) describe all parameters of a process')
+  .action(function(proc_id) {
+    pm2.describe(proc_id);
+  });
+
+commander.command('show <name|id>')
+  .description('(alias) describe all parameters of a process')
   .action(function(proc_id) {
     pm2.describe(proc_id);
   });
 
 commander.command('env <id>')
-  .description('(alias) describe all parameters of a process id')
+  .description('list all environment variables of a process id')
   .action(function(proc_id) {
     pm2.env(proc_id);
-  });
-
-commander.command('show <id>')
-  .description('(alias) describe all parameters of a process id')
-  .action(function(proc_id) {
-    pm2.describe(proc_id);
   });
 
 //


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | NA
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->
- `describe` command operates with process `name` or `id`.
- `env` command is not a alias of `describe` command