### PR TITLE
Fix CLI ignore_watch

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -691,7 +691,7 @@ class API {
 
     if (opts.ignoreWatch) {
       flagWatch.handleFolders(opts.ignoreWatch, ignoreFileArray);
-      if (app_conf.ignore_watch) {
+      if (ignoreFileArray.length > 0) {
         app_conf.ignore_watch = ignoreFileArray;
       }
     }


### PR DESCRIPTION
The changed line has the CLI ignore_watch overwritten with an empty array.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->