### PR TITLE
fix: ANSI escape codes with --watch #3884

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -589,8 +589,8 @@ class API {
       if (opts && opts.rawArgs && opts.rawArgs.indexOf('--watch') > -1) {
         var moment = require('moment');
         function show() {
-          process.stdout.write('\\033[2J');
-          process.stdout.write('\\033[0f');
+          process.stdout.write('\x1b[2J');
+          process.stdout.write('\x1b[0f');
           console.log('Last refresh: ', moment().format('LTS'));
           that.Client.executeRemote('getMonitorData', {}, function(err, list) {
             UX.dispAsTable(list, null);


### PR DESCRIPTION
Running `pm2 list --watch` doesn't update the status table properly.

The escape code should be `\033`, but that doesn't work in strict mode, probably because of that it was changed to `\\033` which isn't valid either.

Tests failed
```
[~] Starting test ./test/e2e/misc/nvm-node-version.sh
######## ✘ Errors in setting interpreters
```
But that doesn't seem to be related to this change.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #3884
| License       | MIT
| Doc PR        | n/a
<!--
*Please update this template with something that matches your PR*
-->