### PR TITLE
Fix --wait-ip option doesn't work

### DIFF
--- a/lib/templates/init-scripts/systemd-online.tpl
+++ b/lib/templates/init-scripts/systemd-online.tpl
@@ -1,8 +1,7 @@
 [Unit]
 Description=PM2 process manager
 Documentation=https://pm2.keymetrics.io/
-After=network.target network-online.target
-Wants=network-online.target
+After=network-online.target
 Restart=on-failure
 
 [Service]
@@ -20,4 +19,4 @@ ExecReload=%PM2_PATH% reload all
 ExecStop=%PM2_PATH% kill
 
 [Install]
-WantedBy=multi-user.target network-online.target
+WantedBy=network-online.target


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3347
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->
The below line is not necessary.
```
Wants=network-online.target
```
pm2 still launches even though it does not meet "network-online.target".