### PR TITLE
add 'max' for instances option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -284,7 +284,7 @@ interface Pm2Env {
   /**
    * The number of running instances.
    */
-  instances?: number;
+  instances?: number | 'max';
   /**
    * The path of the script being run in this process.
    */


### PR DESCRIPTION
ref: http://pm2.keymetrics.io/docs/usage/cluster-mode/#usage

Added because the type of instance option needs to include max

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | 
