### PR TITLE
Support Solaris SMF as init system

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -171,7 +171,7 @@ module.exports = function(CLI) {
     require('shelljs').exec(commands.join('&& '), function(code, stdout, stderr) {
       Common.printOut(stdout);
       Common.printOut(stderr);
-      if (code == 0) {~
+      if (code == 0) {
         Common.printOut(cst.PREFIX_MSG + chalk.bold('Init file disabled.'));
       } else {
         Common.printOut(cst.ERROR_MSG + chalk.bold('Return code : ' + code));

--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -12,6 +12,7 @@ var exec         = require('child_process').exec;
 var Common       = require('../Common.js');
 var cst          = require('../../constants.js');
 var util 	       = require('util');
+var tmpPath      = require('os').tmpdir;
 
 module.exports = function(CLI) {
   /**
@@ -43,6 +44,7 @@ module.exports = function(CLI) {
       'launchctl'  : 'launchd',
       'sysrc'      : 'rcd',
       'rcctl'      : 'rcd-openbsd',
+      'svcadm'     : 'smf'
     };
     var init_systems = Object.keys(hash_map);
 
@@ -158,12 +160,18 @@ module.exports = function(CLI) {
         'rm ' + destination
       ];
       break;
+    case 'smf':
+      service_name = (opts.serviceName || 'pm2_' + user);
+      commands = [
+        'svcadm disable ' + service_name,
+        'svccfg delete ' + service_name
+      ]
     };
 
     require('shelljs').exec(commands.join('&& '), function(code, stdout, stderr) {
       Common.printOut(stdout);
       Common.printOut(stderr);
-      if (code == 0) {
+      if (code == 0) {~
         Common.printOut(cst.PREFIX_MSG + chalk.bold('Init file disabled.'));
       } else {
         Common.printOut(cst.ERROR_MSG + chalk.bold('Return code : ' + code));
@@ -179,7 +187,7 @@ module.exports = function(CLI) {
   /**
    * Startup script generation
    * @method startup
-   * @param {string} platform type (centos|redhat|amazon|gentoo|systemd)
+   * @param {string} platform type (centos|redhat|amazon|gentoo|systemd|smf)
    */
   CLI.prototype.startup = function(platform, opts, cb) {
     var that = this;
@@ -299,6 +307,17 @@ module.exports = function(CLI) {
       commands = [
         'chmod +x ' + destination,
         'rc-update add ' + service_name + ' default'
+      ];
+      break;
+    case 'smf':
+    case 'sunos':
+    case 'solaris':
+      template = getTemplate('smf');
+      service_name = (opts.serviceName || 'pm2_' + user);
+      destination = path.join(tmpPath(), service_name + '.xml');
+      commands = [
+        'svccfg import ' + destination,
+        'svcadm enable ' + service_name
       ];
       break;
     default:

--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -66,7 +66,7 @@ module.exports = function(CLI) {
     var commands;
     var that = this;
     var actual_platform = detectInitSystem();
-    var user = opts.user || process.env.USER;
+    var user = opts.user || process.env.USER || process.env.LOGNAME; // Use LOGNAME on Solaris-like systems
     var service_name = (opts.serviceName || 'pm2-' + user);
     var openrc_service_name = 'pm2';
     var launchd_service_name = (opts.serviceName || 'pm2.' + user);
@@ -192,7 +192,7 @@ module.exports = function(CLI) {
   CLI.prototype.startup = function(platform, opts, cb) {
     var that = this;
     var actual_platform = detectInitSystem();
-    var user = (opts.user || process.env.USER);
+    var user = (opts.user || process.env.USER || process.env.LOGNAME); // Use LOGNAME on Solaris-like systems
     var service_name = (opts.serviceName || 'pm2-' + user);
     var openrc_service_name = 'pm2';
     var launchd_service_name = (opts.serviceName || 'pm2.' + user);

--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -164,7 +164,7 @@ module.exports = function(CLI) {
       service_name = (opts.serviceName || 'pm2_' + user);
       commands = [
         'svcadm disable ' + service_name,
-        'svccfg delete ' + service_name
+        'svccfg delete -f ' + service_name
       ]
     };
 

--- a/lib/templates/init-scripts/smf.tpl
+++ b/lib/templates/init-scripts/smf.tpl
@@ -21,6 +21,7 @@
         </method_context>
 
         <exec_method type="method" name="start" exec="%PM2_PATH% resurrect" timeout_seconds="60"/>
+        <exec_method type="method" name="refresh" exec="%PM2_PATH% reload all" timeout_seconds="60"/>
         <exec_method type="method" name="stop" exec="%PM2_PATH% kill" timeout_seconds="60"/>
         
         <property_group name="startd" type="framework">

--- a/lib/templates/init-scripts/smf.tpl
+++ b/lib/templates/init-scripts/smf.tpl
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="%SERVICE_NAME%">
+    <service name="application/%SERVICE_NAME%" type="service" version="1">
+        <create_default_instance enabled="false"/>
+        <single_instance/>
+        
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/milestone/network:default"/>
+        </dependency>
+        
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local"/>
+        </dependency>
+        
+        <method_context>
+            <method_environment>
+                <envvar name='PATH' value="%NODE_PATH%:/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin"/>
+                <envvar name='PM2_HOME' value="%HOME_PATH%"/>
+            </method_environment>
+        </method_context>
+
+        <exec_method type="method" name="start" exec="%PM2_PATH% resurrect" timeout_seconds="60"/>
+        <exec_method type="method" name="stop" exec="%PM2_PATH% kill" timeout_seconds="60"/>
+        
+        <property_group name="startd" type="framework">
+            <propval name="duration" type="astring" value="contract"/>
+            <propval name="ignore_error" type="astring" value="core,signal"/>
+        </property_group>
+        
+        <property_group name="application" type="application"></property_group>
+        <stability value="Evolving"/>
+        
+        <template>
+            <common_name>
+                <loctext xml:lang="C">
+                    PM2 process manager
+                </loctext>
+            </common_name>
+        </template>
+    </service>
+</service_bundle>


### PR DESCRIPTION
Currently, when running the command `pm2 startup` on Oracle Solaris or illumos-based systems like SmartOS, OpenIndiana, etc. will throw up an `Init system not found` error.

This PR adds support for using the Solaris SMF system for starting PM2 which is available on Solaris 10 or above that replaces `/etc/init.d` scripts on such platform.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A