### PR TITLE
3.5.x: Process.send('ready') does not trigger SIGINT

### DIFF
--- a/lib/God/Reload.js
+++ b/lib/God/Reload.js
@@ -121,38 +121,46 @@ function hardReload(God, id, wait_msg, cb) {
 
   old_worker.pm2_env.pm_id = t_key;
   old_worker.pm_id = t_key;
-
+  var timer = null;
+  var readySignalSent = false;
+  
+  var onListen = function () {
+    clearTimeout(timer);
+    readySignalSent = true;
+    console.log('-reload- New worker listening');
+    return God.deleteProcessId(t_key, cb);
+  };
+  
+  var listener = function (packet) {
+    if (packet.raw === 'ready' &&
+        packet.process.name === old_worker.pm2_env.name &&
+        packet.process.pm_id === id) {
+      God.bus.removeListener('process:msg', listener);
+      return onListen();
+    }
+  };
+  
+  if (wait_msg !== 'listening') {
+    God.bus.on('process:msg', listener);
+  }
+  
   God.executeApp(new_env, function(err, new_worker) {
     if (err) return cb(err);
 
-    var timer = null;
-
-    var onListen = function () {
-      clearTimeout(timer);
-      console.log('-reload- New worker listening');
-      return God.deleteProcessId(t_key, cb);
-    };
-
     // Bind to know when the new process is up
-    if (wait_msg == 'listening')
+    if (wait_msg === 'listening') {
       new_worker.once('listening', onListen);
-    else {
-      var listener = function (packet) {
-        if (packet.raw === 'ready' &&
-            packet.process.name === new_worker.pm2_env.name &&
-            packet.process.pm_id === new_worker.pm2_env.pm_id) {
-          God.bus.removeListener('process:msg', listener)
-          return onListen();
-        }
-      }
-      God.bus.on('process:msg', listener);
     }
 
     timer = setTimeout(function() {
-      if (wait_msg == 'listening')
+      if (readySignalSent) {
+        return;
+      }
+      
+      if (wait_msg === 'listening')
         new_worker.removeListener(wait_msg, onListen);
       else
-        God.bus.removeListener('process:msg', listener)
+        God.bus.removeListener('process:msg', listener);
 
       return God.deleteProcessId(t_key, cb);
     }, new_env.listen_timeout || cst.GRACEFUL_LISTEN_TIMEOUT);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4300,#4271
| License       | MIT

Related to this issues #4300,#4271

I've created branch from 3.5.1 (latest 3.x.x) by that moment