### PR TITLE
remove optional gkt dependency from 2.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm2",
   "preferGlobal": true,
-  "version": "2.10.4",
+  "version": "2.10.5",
   "engines": {
     "node": ">=0.12"
   },
@@ -191,9 +191,6 @@
   "devDependencies": {
     "mocha": "^3.5",
     "should": "^11"
-  },
-  "optionalDependencies": {
-    "gkt": "https://tgz.pm2.io/gkt-1.0.0.tgz"
   },
   "bugs": {
     "url": "https://github.com/Unitech/pm2/issues"


### PR DESCRIPTION
Removing the optional gkt dependency from the 2.x branch since the gkt server is responding with 503 and breaking builds.

Related to: https://github.com/Unitech/pm2/issues/4202

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2700 
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->