### PR TITLE
Fix watch argument when used in another program (ie -- --watch)

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -28,6 +28,7 @@ var pkg         = require('../package.json');
 var hf = require('./API/Modules/flagExt.js');
 var Configuration = require('./Configuration.js');
 const semver = require('semver')
+var hasWatchArgument = require('./Utility.js').hasWatchArgument;
 
 var IMMUTABLE_MSG = chalk.bold.blue('Use --update-env to update environment variables');
 
@@ -327,7 +328,7 @@ class API {
 
     var that = this;
     if (util.isArray(opts.watch) && opts.watch.length === 0)
-      opts.watch = (opts.rawArgs ? !!~opts.rawArgs.indexOf('--watch') : !!~process.argv.indexOf('--watch')) || false;
+      opts.watch = hasWatchArgument(opts.rawArgs || process.argv);
 
     if (Common.isConfigFile(cmd) || (typeof(cmd) === 'object')) {
       that._startJson(cmd, opts, 'restartProcessId', (err, procs) => {
@@ -622,7 +623,7 @@ class API {
         return cb ? cb(Common.retErr(err)) : that.exitCli(conf.ERROR_EXIT);
       }
 
-      if (opts && opts.rawArgs && opts.rawArgs.indexOf('--watch') > -1) {
+      if (opts && opts.rawArgs && hasWatchArgument(opts.rawArgs)) {
         var moment = require('moment');
         function show() {
           process.stdout.write('\\033[2J');
@@ -1567,7 +1568,7 @@ class API {
     delete appConf.exec_mode;
 
     if (util.isArray(appConf.watch) && appConf.watch.length === 0) {
-      if (!~opts.rawArgs.indexOf('--watch'))
+      if (hasWatchArgument(opts.rawArgs))
         delete appConf.watch
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -4,16 +4,17 @@
  * can be found in the LICENSE file.
  */
 
-var debug          = require('debug')('pm2:client');
-var Common         = require('./Common.js');
-var KMDaemon       = require('@pm2/agent/src/InteractorClient');
-var rpc            = require('pm2-axon-rpc');
-var forEach        = require('async/forEach');
-var axon           = require('pm2-axon');
-var util           = require('util');
-var fs             = require('fs');
-var path           = require('path');
-var pkg            = require('../package.json');
+var debug            = require('debug')('pm2:client');
+var Common           = require('./Common.js');
+var KMDaemon         = require('@pm2/agent/src/InteractorClient');
+var rpc              = require('pm2-axon-rpc');
+var forEach          = require('async/forEach');
+var axon             = require('pm2-axon');
+var util             = require('util');
+var fs               = require('fs');
+var path             = require('path');
+var pkg              = require('../package.json');
+var hasWatchArgument = require('./Utility.js').hasWatchArgument
 
 function noop() {}
 
@@ -509,9 +510,12 @@ Client.prototype.executeRemote = function executeRemote(method, app_conf, fn) {
   else if (method.indexOf('kill') !== -1) {
     this.stopWatch('deleteAll', app_conf);
   }
-  else if (method.indexOf('restartProcessId') !== -1 && process.argv.indexOf('--watch') > -1) {
-    delete app_conf.env.current_conf.watch;
-    this.toggleWatch(method, app_conf);
+  else if (method.indexOf('restartProcessId') !== -1) {
+    if (app_conf.env.current_conf.watch === true || hasWatchArgument(process.argv)) {
+      this.toggleWatch(method, app_conf);
+    } else {
+      delete app_conf.env.current_conf.watch;
+    }
   }
 
   if (!this.client || !this.client.call) {

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -16,6 +16,7 @@ var util      = require('util');
 var url       = require('url');
 var dateFns = require('date-fns')
 var findPackageJson = require('./tools/find-package-json')
+var minimist = require('minimist');
 
 var Utility = module.exports = {
   findPackageVersion : function(fullpath) {
@@ -273,6 +274,9 @@ var Utility = module.exports = {
     s[19] = hexDigits.substr((s[19] & 0x3) | 0x8, 1);
     s[8] = s[13] = s[18] = s[23] = "-";
     return s.join("");
+  },
+  hasWatchArgument: function (argv) {
+    var parsedArguments = minimist(argv ? argv.slice(2) : process.argv.slice(2), {boolean: 'watch'})
+    return parsedArguments.watch;
   }
-
 };

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "debug": "4.1.1",
     "eventemitter2": "5.0.1",
     "fclone": "1.0.11",
+    "minimist": "^1.2.0",
     "mkdirp": "0.5.1",
     "moment": "2.24.0",
     "needle": "2.4.0",

--- a/test/programmatic/watcher.js
+++ b/test/programmatic/watcher.js
@@ -1,9 +1,10 @@
 var should = require('should');
 var p = require('path');
-var fs = require('fs')
-var EventEmitter = require('events').EventEmitter
+var fs = require('fs');
+var EventEmitter = require('events').EventEmitter;
 var PM2  = require('../..');
-var extend = require('util')._extend
+var extend = require('util')._extend;
+var hasWatchArgument = require('../../lib/Utility.js').hasWatchArgument;
 
 var cwd = __dirname + '/../fixtures/watcher';
 
@@ -196,5 +197,11 @@ describe('Watcher', function() {
     })
 
     pm2.delete(paths.json, errShouldBeNull)
+  })
+
+  it('should test watch argument', function() {
+    should(hasWatchArgument([0, 0, '--watch'])).eql(true)
+    should(hasWatchArgument([0, 0, '--', '--watch'])).eql(false)
+    should(hasWatchArgument([0, 0, '--somethingelse'])).eql(false)
   })
 })


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | na
| License       | MIT
| Doc PR        | na

Sometimes when running a command inside pm2 you could do something like

```
pm2 start node -- npm run builder -- --watch
```

This would mean that the `builder` script will receive the `--watch` argument by convention. 
When PM2 received these argument, he would start the process and watch for changes but if we wanted that we should do:

```
pm2 start --watch node -- npm run builder -- --watch
```

This PR fixes the wrong behavior using `minimist` to parse arguments. Note that this was already a peer dependency of the project (installation time should not vary).