### PR TITLE
fix: pm2-runtime auto-exit check ignores module like logrotate

### DIFF
--- a/lib/binaries/Runtime4Docker.js
+++ b/lib/binaries/Runtime4Docker.js
@@ -169,8 +169,9 @@ var Runtime = {
         var appOnline = 0;
 
         apps.forEach(function (app) {
-          if (app.pm2_env.status === cst.ONLINE_STATUS ||
-              app.pm2_env.status === cst.LAUNCHING_STATUS) {
+          if (!app.pm2_env.pmx_module &&
+            (app.pm2_env.status === cst.ONLINE_STATUS ||
+              app.pm2_env.status === cst.LAUNCHING_STATUS)) {
             appOnline++;
           }
         });


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4372
| License       | MIT
| Doc PR        | 
<!--
*Please update this template with something that matches your PR*
-->