### PR TITLE
Adding optional switch to enable graceful shutdown on Windows

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -100,6 +100,9 @@ var csts = {
 
   WORKER_INTERVAL         : process.env.PM2_WORKER_INTERVAL || 30000,
   KILL_TIMEOUT            : process.env.PM2_KILL_TIMEOUT || 1600,
+  KILL_SIGNAL             : process.env.PM2_KILL_SIGNAL || 'SIGINT',
+  KILL_USE_SEND           : process.env.PM2_KILL_USE_SEND || false,
+
   PM2_PROGRAMMATIC        : typeof(process.env.pm_id) !== 'undefined' || process.env.PM2_PROGRAMMATIC,
   PM2_LOG_DATE_FORMAT     : process.env.PM2_LOG_DATE_FORMAT !== undefined ? process.env.PM2_LOG_DATE_FORMAT : 'YYYY-MM-DDTHH:mm:ss'
 

--- a/lib/God/Methods.js
+++ b/lib/God/Methods.js
@@ -207,18 +207,32 @@ module.exports = function(God) {
   God.killProcess = function(pid, pm2_env, cb) {
     if (!pid) return cb({msg : 'no pid passed or null'});
 
-    var mode = pm2_env.exec_mode;
+    if (cst.KILL_USE_SEND && typeof(pm2_env.pm_id) === 'number') {
+      var proc = God.clusters_db[pm2_env.pm_id];
+
+      if (proc && proc.send) {
+        try {
+          proc.send(cst.KILL_SIGNAL);
+        } catch (e) {
+          console.error('[SimpleKill] %s pid can not be killed', pid, e.stack, e.message);
+        }
+        return God.processIsDead(pid, pm2_env, cb);
+      }
+      else {
+        console.log('[SimpleKill] %s pid cannot be notified with send()', pid);
+      }
+    }
 
     if (pm2_env.treekill !== true) {
       try {
-        process.kill(parseInt(pid), process.env.PM2_KILL_SIGNAL || 'SIGINT');
+        process.kill(parseInt(pid), cst.KILL_SIGNAL);
       } catch(e) {
         console.error('[SimpleKill] %s pid can not be killed', pid, e.stack, e.message);
       }
       return God.processIsDead(pid, pm2_env, cb);
     }
     else {
-      treekill(parseInt(pid), process.env.PM2_KILL_SIGNAL || 'SIGINT', function(err) {
+      treekill(parseInt(pid), cst.KILL_SIGNAL, function(err) {
         return God.processIsDead(pid, pm2_env, cb);
       });
     }

--- a/test/e2e/cli/reload.sh
+++ b/test/e2e/cli/reload.sh
@@ -107,3 +107,23 @@ should 'should not restart' 'restart_time: 0' 1
 #$pm2 web
 #$pm2 reload all
 $pm2 kill
+
+############### SEND() instead of KILL()
+$pm2 kill
+export PM2_KILL_USE_SEND='true'
+
+$pm2 start signal-send.js
+should 'should start processes' 'online' 1
+
+OUT_LOG=`$pm2 prettylist | grep -m 1 -E "pm_out_log_path:" | sed "s/.*'\([^']*\)',/\1/"`
+> $OUT_LOG
+
+$pm2 reload signal-send.js
+sleep 1
+
+OUT=`grep "SIGINT" "$OUT_LOG" | wc -l`
+[ $OUT -eq 1 ] || fail "Signal not received by the process name"
+success "Processes sucessfully receives the signal"
+
+unset PM2_KILL_USE_SEND
+$pm2 kill

--- a/test/fixtures/signal-send.js
+++ b/test/fixtures/signal-send.js
@@ -1,0 +1,7 @@
+
+setInterval(function() {
+}, 1000);
+
+process.on('message', function (msg) {
+  console.log(msg);
+});

--- a/test/fixtures/signals/delayed_send.js
+++ b/test/fixtures/signals/delayed_send.js
@@ -1,0 +1,11 @@
+
+setInterval(function() {
+  // Do nothing to keep process alive
+}, 1000);
+
+process.on('message', function (msg) {
+  if (msg === 'SIGINT') {
+    console.log('SIGINT message received but forbid exit');
+  }
+});
+

--- a/test/programmatic/signals.js
+++ b/test/programmatic/signals.js
@@ -76,7 +76,7 @@ describe('Signal kill (+delayed)', function() {
 
     it('should start a script', function(done) {
       pm2.start({
-        script : './delayed_sigint.js',
+        script : './signals/delayed_sigint.js',
         name : 'delayed-sigint'
       }, function(err, data) {
         proc1 = data[0];
@@ -199,6 +199,134 @@ describe('Signal kill (+delayed)', function() {
       }, 4500);
 
       pm2.stop('delayed-sigint', function(err, app) {
+        //done(err);
+      });
+
+    });
+  });
+
+});
+
+describe('Message kill (signal behavior override via PM2_KILL_USE_SEND, +delayed)', function() {
+  var proc1 = null;
+  var appName = 'delayed-send';
+
+  process.env.PM2_KILL_USE_SEND = true;
+
+  var pm2 = new PM2.custom({
+    cwd : __dirname + '/../fixtures',
+  });
+
+  after(function(done) {
+    pm2.delete('all', function(err, ret) {
+      pm2.kill(done);
+    });
+  });
+
+  before(function(done) {
+    pm2.connect(function() {
+      pm2.delete('all', function(err, ret) {
+        done();
+      });
+    });
+  });
+
+  describe('with 1000ms PM2_KILL_TIMEOUT (environment variable)', function() {
+    it('should set 1000ms to PM2_KILL_TIMEOUT', function(done) {
+      process.env.PM2_KILL_TIMEOUT = 1000;
+
+      pm2.update(function() {
+        done();
+      });
+    });
+
+    it('should start a script', function(done) {
+      pm2.start({
+        script : './signals/delayed_send.js',
+        name : appName,
+      }, function(err, data) {
+        proc1 = data[0];
+        should(err).be.null();
+        setTimeout(done, 1000);
+      });
+    });
+
+    it('should stop script after 1000ms', function(done) {
+      setTimeout(function() {
+        pm2.describe(appName, function(err, list) {
+          should(err).be.null();
+          list[0].pm2_env.status.should.eql('stopping');
+        });
+      }, 500);
+
+      setTimeout(function() {
+        pm2.describe(appName, function(err, list) {
+          should(err).be.null();
+          list[0].pm2_env.status.should.eql('stopped');
+          done();
+        });
+      }, 1500);
+
+      pm2.stop(appName, function(err, app) {
+        //done(err);
+      });
+      
+    });
+  });
+
+  describe('[CLUSTER MODE] with 1000ms PM2_KILL_TIMEOUT (environment variable)', function() {
+    it('should set 1000ms to PM2_KILL_TIMEOUT', function(done) {
+      process.env.PM2_KILL_TIMEOUT = 1000;
+
+      pm2.update(function() {
+        done();
+      });
+    });
+
+    it('should start a script', function(done) {
+      pm2.start({
+        script : './signals/delayed_send.js',
+        name : appName,
+        exec_mode : 'cluster'
+      }, function(err, data) {
+        proc1 = data[0];
+        should(err).be.null();
+        setTimeout(done, 1000);
+      });
+    });
+
+    it('should stop script after 1000ms', function(done) {
+      setTimeout(function() {
+        pm2.describe(appName, function(err, list) {
+          should(err).be.null();
+          list[0].pm2_env.status.should.eql('stopping');
+        });
+      }, 500);
+
+      setTimeout(function() {
+        pm2.describe(appName, function(err, list) {
+          should(err).be.null();
+          list[0].pm2_env.status.should.eql('stopped');
+          done();
+        });
+      }, 1500);
+
+      pm2.stop(appName, function(err, app) {
+        //done(err);
+      });
+
+    });
+
+    it('should reload script', function(done) {
+      setTimeout(function() {
+        pm2.describe(appName, function(err, list) {
+          should(err).be.null();
+          list[0].pm2_env.status.should.eql('online');
+          done();
+        });
+      }, 1500);
+
+      pm2.reload(appName, function(err, app) {
         //done(err);
       });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3651, #3691, #3555
| License       | MIT

---

*Problem*:
There is no official and easy way to implement the graceful shutdown on Windows.

For graceful shutdown PM2 pretty much relies on the `process.kill()` and applications being able to ignore `SIGINT` to delay shutdown, but it doesn't work on Windows.
https://pm2.keymetrics.io/docs/usage/signals-clean-restart/

There are variables you can set to alter the PM2 kill behavior: `PM2_KILL_SIGNAL` (`SIGINT` by default), `PM2_KILL_TIMEOUT` (`1600` by default), the `--treekill` parameter (`true` by default), and kill retry time.

---

There are a couple of issues with PM2's graceful shutdown on Windows:
* The `shutdown` message is only sent if the `softReload` method is used: https://github.com/Unitech/pm2/blob/bf1c605fd40a8b4ec5f76aca95debe94bdd7a357/lib/God/Reload.js#L77 I.e. it works only if you call `pm2 startOrGracefulReload <json>`, and if the application is automatically restarted by the PM2. **But** it does not work for kill/stop/restart/reload **and** for scale down operations.
* People are often confused about `process.kill()` behavior on Windows due to unclear documentation (https://nodejs.org/api/process.html#process_process_kill_pid_signal) - Windows doesn't support signals; instead, nodejs emulates `process.kill()` behavior for 3 signals and ignores everything else: `SIGINT`/`SIGTERM` - terminates app; `0` - checks whether the process exists. What is often confusing is that if you run nodejs app in cmd and use `Ctrl-C`, it _does_ receive `SIGINT`, - but it's emulated.

---

*Attempted solutions*:
1. Existing bugreports. There a bunch of posts on stackoverflow/github about emulating `SIGINT`/`SIGBREAK` by handling `STDIN` closure: https://stackoverflow.com/questions/10021373/what-is-the-windows-equivalent-of-process-onsigint-in-node-js
Doesn't work, and it I'm not sure how well that idea is going to work with different CLI modes PM2 can launch the app. 
2. https://www.npmjs.com/package/windows-kill - native nodejs plugin (up to API 67?).
Can actually invoke the signal handler in the nodejs, but it does so for all child processes too, which makes it unusable in Cluster mode - signal will be received by all instances.
But that module replaces global `process.kill`, so I thought about doing it manually.
NOTE; If you play with the `process.kill()`, you have to disable `treekill`, because it uses Windows utility by default instead.
3. `process.kill()` substitution. You can wrap PM2 startup in another script and replace `process.kill` there. This will still allow running PM2 as a service, and not only in the standalone mode.
The idea there is to handle the `SIGINT` signal to notify an app that is about to be closed, and rely on the PM2 kill timeout to send the `SIGTERM` and explicitly close the app.
It's actually a 'reasonable' workaround, but you can't use any messaging methods (like `sendDataToProcessId` or `trigger` custom action), because the process is marked as `stopping` internally and all communication to such processes is blocked: https://github.com/Unitech/pm2/blob/91470b622a40f81091bbbaea4584f44ec16ee5b4/lib/God/ActionMethods.js#L714
So you eventually will have to get access to the `God.clusters_db[]` object to be able to use `process.send` - this is not 'trivial'.
4. Since the `process.kill()` replacement is quirky and is tightly coupled with PM2 version (relies on veriable names and etc.), you can notify the specific app instance with the `sendDataToProcessId` or another way, if you can get the instance that is going to be shutdown.
It's easy to guess, however, also PM2 version-specific, but somewhat less than previous item.
Let's say you want to stop/scale down an app. You need to call the `describe` or `list` first to get ID of the instances and their order. PM2 internally represents this list in the same order it kills apps - it uses filtered arrays and a simple `for` loop, so it's easy to guess and pre-notify apps. And you can rely on the 'shutdown' message for the auto-restarts.

---

I thought about fixing the higher-level abstractions, but it feels like that the change in that business logic is too risky and won't be accepted (considering the previous PRs I've seen):
`God.killProcess` is called only from the `God.stopProcessId`, so it could be refactored to accept switch to soft/hard stop the app. But if you do that, there is no need in the `softReload` function, and entire `startOrGracefulReload` feature relies on it.
And it's hard to say what kind of regressions could be introduced by affecting the timing of the `shutdown` message.

---

*Proposed solution*:

I think the easiest way to provide a Windows-specific workaround is to introduce a new global switch (`PM2_KILL_USE_SEND` environment variable, name TBD) to change how `God.killProcess` works - it's intent actually not to kill the process, but to notify it, and then the `God.processIsDead` method explicitly kills the process on timeout, if it's not dead.
So, by allowing `God.killProcess` to use `process.send()` instead of `process.kill()`, apps can be notified and then killed by timeout, if needed.
It's also possible to change the shutdown message with the existing `PM2_KILL_SIGNAL` variable.

Sample app:
```
setInterval(() => {}, 1000);

process.on('message', msg => {
  if (msg === 'SIGINT') {
    // Perform cleanup, app will be automatically terminated on kill timeout.
  }
});
```
