### PR TITLE
fix: display correct username

### DIFF
--- a/lib/API/CliUx.js
+++ b/lib/API/CliUx.js
@@ -400,7 +400,7 @@ UX.dispAsTable = function(list, sys_infos) {
           Object.keys(users).forEach(function(username) {
             var user = users[username]
             if (user.userId == l.pm2_env.uid) {
-              l.pm2_env.uid = user.name
+              l.pm2_env.uid = user.username;  
             }
           })
         }
@@ -452,7 +452,7 @@ UX.dispAsTable = function(list, sys_infos) {
           Object.keys(users).forEach(function(username) {
             var user = users[username]
             if (user.userId == l.pm2_env.uid) {
-              l.pm2_env.uid = user.name
+              l.pm2_env.uid = user.username;
             }
           })
         }

--- a/lib/tools/passwd.js
+++ b/lib/tools/passwd.js
@@ -16,7 +16,7 @@ var getUsers = function() {
         password : fields[1],
         userId : fields[2],
         groupId : fields[3],
-        name : fields[4],
+        name : fields[4].split(',')[0],
         homedir : fields[5],
         shell : fields[6]
       };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4431
| License       | MIT


This pull request should solve two issues:
1. When a process is run with uid and if the user doesn't have fullname assigned, the username is being displayed incorrectly as "root" in pm2 status
2. In Ubuntu, the value for fields[4] attribute in passwd.js consists of multiple values like full name,room number, work phone, home phone and other seperated by commas. If none of them have values assigned, the fields[4] attribute will end up having value as ",,,". 
