### PR TITLE
fix: stop and delete cron immediately on deletion of a process

### DIFF
--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -380,6 +380,8 @@ module.exports = function(God) {
   God.deleteProcessId = function(id, cb) {
     God.stopProcessId(id, function(err, proc) {
       if (err) return cb(God.logAndGenerateError(err), {});
+      var proc = God.clusters_db[id];
+      God.deleteCron(proc);
       // ! transform to slow object
       delete God.clusters_db[id];
 
@@ -615,6 +617,24 @@ module.exports = function(God) {
     }
 
     return fn(null, {success:true});
+  };
+
+  /**
+   * Deletes the cron job on deletion of process
+   */
+  God.deleteCron = function(proc) {
+    if (!proc ||
+      !proc.pm2_env ||
+      proc.pm2_env.pm_id === undefined ||
+      !proc.pm2_env.cron_restart ||
+      !God.CronJobs.has(proc.pm2_env.pm_id))
+    return;
+    
+    console.log('[PM2] Deregistering a cron job on:', proc.pm2_env.pm_id);
+
+    var job = God.CronJobs.get(proc.pm2_env.pm_id);
+    job.stop();
+    God.CronJobs.delete(proc.pm2_env.pm_id);
   };
 
   /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4485 
| License       | MIT

Solves two problems:
1. Stops and deletes the cron job during the process deletion itself. Soft reload won't be called even in absence of process.
2. Doesn't restart wrong process in the case where if new process gets spun up and gets same process id assigned to it as well