### PR TITLE
Fix an error for pm2 path on Windows.

### DIFF
--- a/lib/Daemon.js
+++ b/lib/Daemon.js
@@ -45,7 +45,7 @@ Daemon.prototype.start = function() {
 
     console.error('[PM2] Resurrecting PM2');
 
-		var path = cst.IS_WINDOWS ? process.cwd() + '/bin/pm2' : process.env['_'];
+		var path = cst.IS_WINDOWS ? __dirname + '/../bin/pm2' : process.env['_'];
     var fork_new_pm2 = require('child_process').spawn('node', [path, 'update'], {
       detached: true,
       stdio: 'inherit'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3793
| License       | MIT

Although I do not use version 2, still have #3793 .
I propose change the path on Windows when get error and restart pm2.
