### PR TITLE
Add s390x support for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,16 @@ git:
   depth: 5
 os:
   - linux
+arch: 
+  - amd64
+  - s390x
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install python3
   - sudo apt-get install php7.0-cli
+  - if [[ $(uname -m) == 's390x' ]]; then
+      sudo apt-get install bc;
+    fi
 services:
   - docker
 install:


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

