### PR TITLE
add `ignore_watch` to StartOptions types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -395,6 +395,7 @@ export interface StartOptions {
    * already running). If force is set to true, pm2 will start a new instance of that script.
    */
   force?: boolean;
+  ignore_watch?: string[];
   cron?: any;
   execute_command?: any;
   write?: any;


### PR DESCRIPTION
Make typescript allow `ignore_watch` option to be set on `start()`

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
