### PR TITLE
Fix failing npm audit: mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "eventemitter2": "5.0.1",
     "fclone": "1.0.11",
     "lodash": "4.17.14",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^0.5.3",
     "moment": "2.24.0",
     "needle": "2.4.0",
     "pidusage": "2.0.17",


### PR DESCRIPTION
NPM Audit was failing with `mkdirp@0.5.1` so I've upgraded it to `0.5.3`.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4638 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->