### PR TITLE
Add .cjs (common JS) as a viable extension

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -251,6 +251,8 @@ Common.isConfigFile = function (filename) {
     return 'yaml';
   if (filename.indexOf('.config.js') !== -1)
     return 'js';
+  if (filename.indexOf('.config.cjs') !== -1)
+    return 'js';
   if (filename.indexOf('.config.mjs') !== -1)
     return 'mjs';
   return null;
@@ -283,7 +285,7 @@ Common.parseConfig = function(confObj, filename) {
            filename.indexOf('.yaml') > -1) {
     return yamljs.parse(confObj.toString());
   }
-  else if (filename.indexOf('.config.js') > -1 || filename.indexOf('.config.mjs') > -1) {
+  else if (filename.indexOf('.config.js') > -1 || filename.indexOf('.config.cjs') > -1 || filename.indexOf('.config.mjs') > -1) {
     var confPath = require.resolve(path.resolve(filename));
     delete require.cache[confPath];
     return require(confPath);


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | #4652 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->
This pull request fixes the following problem: If you define `type: module` inside package.json, none of the extensions on config file would work (tried with mjs and js). This happens on `pm2 deploy` command.

This is merely a temporary solution; it would be nice to support module exports, but due to require being used [here](https://github.com/Unitech/pm2/blob/master/lib/Common.js#L289), we can't. I believe this happens only on `pm2 deploy` command.