### PR TITLE
allow restart_delay to be used as ceil to exp_backoff_restart_delay

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -461,7 +461,7 @@ God.handleExit = function handleExit(clu, exit_code, kill_signal) {
       restart_delay = proc.pm2_env.exp_backoff_restart_delay
     }
     else {
-      proc.pm2_env.prev_restart_delay = Math.floor(Math.min(15000, proc.pm2_env.prev_restart_delay * 1.5))
+      proc.pm2_env.prev_restart_delay = Math.floor(Math.min(parseInt(proc.pm2_env.restart_delay) || 15000, proc.pm2_env.prev_restart_delay * 1.5))
       restart_delay = proc.pm2_env.prev_restart_delay
     }
     console.log(`App [${clu.pm2_env.name}:${clu.pm2_env.pm_id}] will restart in ${restart_delay}ms`)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -390,6 +390,10 @@ export interface StartOptions {
    */
   watch?: boolean|string[];
   /**
+   * The exponential backoff restart will increase incrementally the time between restarts, reducing the pressure on your DB or your external provider
+   */
+  exp_backoff_restart_delay?: number;
+  /**
    * (Default: false) By default, pm2 will only start a script if that script isn’t
    * already running (a script is a path to an application, not the name of an application
    * already running). If force is set to true, pm2 will start a new instance of that script.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

added a way to configure the ceil of the exponential backoff in a intuitive way(using restart_delay) without breaking compatibility

