### PR TITLE
Fix a "User" column truncate problem

### DIFF
--- a/lib/API/UX/pm2-ls.js
+++ b/lib/API/UX/pm2-ls.js
@@ -204,7 +204,7 @@ function listModulesAndAppsManaged(list) {
             }
           })
         }
-        obj[key].push(chalk.bold(l.pm2_env.uid || l.pm2_env.username))
+        obj[key].push(l.pm2_env.uid || l.pm2_env.username)
       }
 
       UxHelpers.safe_push(module_table, obj)
@@ -260,7 +260,7 @@ function listModulesAndAppsManaged(list) {
             }
           })
         }
-        obj[key].push(chalk.bold(l.pm2_env.uid || l.pm2_env.username))
+        obj[key].push(l.pm2_env.uid || l.pm2_env.username)
       }
 
       // Watch status


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

After executing the "pm2 ls" command, if the User column is truncated, there will be confusion, as shown in the figure:

![825E751B-AD28-4A93-8F3E-1A1FFCD5BACF](https://user-images.githubusercontent.com/13709/83988796-fa5f3500-a976-11ea-8eb0-6b5fad5db85c.png)