### PR TITLE
fix: fix unit test script

### DIFF
--- a/test/unit.sh
+++ b/test/unit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-alias mocha='../node_modules/.bin/mocha'
+mocha="npx mocha"
 pm2="`type -P node` `pwd`/bin/pm2"
 
 function reset {
@@ -12,7 +12,7 @@ function reset {
 function runUnitTest {
     echo "[~] Starting test $1"
     START=$(date +%s)
-    mocha --exit --bail $1
+    $mocha --exit --bail $1
     RET=$?
 
     if [ $RET -ne 0 ];
@@ -22,7 +22,7 @@ function runUnitTest {
         echo $STR >> unit_time
 
         reset
-        mocha --bail --exit $1
+        $mocha --bail --exit $1
         RET=$?
 
         if [ $RET -ne 0 ];


### PR DESCRIPTION
This commit fixes an issue with the unit test script where it
could not be run without Mocha installed globally since there was
a bug where the alias wasn't working, but if Mocha was installed
globally, it would use that instance to run the tests. However, if
Mocha is not installed globally, then it would fail because it
pointed to the local instance of Mocha using a relative path that
was in direct conflict with the relative path used to run the local
instance of pm2. The npx command fixes these issues by finding the
local instance of a npm binary regardless of what the current
directory is.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->