### PR TITLE
fix: backward compatibility fix for tarball modules

### DIFF
--- a/lib/API/Modules/Modularizer.js
+++ b/lib/API/Modules/Modularizer.js
@@ -39,7 +39,7 @@ Modularizer.install = function (CLI, module_name, opts, cb) {
     Common.logMod(`Installing local NPM module`);
     return NPM.localStart(CLI, opts, cb)
   }
-  else if (opts.tarball || /^[a-z_\.-]+tar\.gz$/ig.test(module_name)) {
+  else if (opts.tarball || /\.tar\.gz$/i.test(module_name)) {
     Common.logMod(`Installing TAR module`);
     TAR.install(CLI, module_name, opts, cb)
   }


### PR DESCRIPTION
#4593 affected backward compatibility, if someone try to install tarball module without tarball option. 

Actually, it contains bad regular expression for following use cases:
1) Module name with digits (`pm install pm2-module-name.tar.gz`)
2) Modules/TAR.js can use Modularizer module_name as module_filepath, but #4593 regular expression is not allowed to specify full path to module (`pm install full/path/to/module/pm2-module-name.tar.gz`)
3) Modules/TAR.js can accept URL (`pm install http://example.com/pm2/pm2-module-name.tar.gz`)

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->
