### PR TITLE
Prevent reloadLogs command from hanging

### DIFF
--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -275,21 +275,23 @@ module.exports = function ForkMode(God) {
       cspr.once('exit', function forkClose(status) {
         try {
           for(var k in stds){
-            if (stds[k].destroy) stds[k].destroy();
-            else if (stds[k].end) stds[k].end();
-            else if (stds[k].close) stds[k].close();
+            if (stds[k] && std[k].destroy) stds[k].destroy();
+            else if (stds[k] && stds[k].end) stds[k].end();
+            else if (stds[k] && stds[k].close) stds[k].close();
             stds[k] = stds[k]._file;
           }
         } catch(e) { God.logAndGenerateError(e);}
       });
 
       cspr._reloadLogs = function(cb) {
-        for (var k in stds){
-          if (stds[k].destroy) stds[k].destroy();
-          else if (stds[k].end) stds[k].end();
-          else if (stds[k].close) stds[k].close();
-          stds[k] = stds[k]._file;
-        }
+        try {
+          for (var k in stds){
+            if (stds[k] && std[k].destroy) stds[k].destroy();
+            else if (stds[k] && stds[k].end) stds[k].end();
+            else if (stds[k] && stds[k].close) stds[k].close();
+            stds[k] = stds[k]._file;
+          }
+        } catch(e) { God.logAndGenerateError(e);}
         //cspr.removeAllListeners();
         Utility.startLogging(stds, cb);
       };


### PR DESCRIPTION
Previously, when the pm2 reloadLogs command was running as a non-root
user, the process will not release and hangs. The reason for the hang
is that the forked process never closes because the object is empty
and doesn't contain the expected object. This commit checks if an
object exists first, before trying to execute methods on it.

Related to: #4781

Co-authored-by: Franck Danard <fdanard@sangoma.com>

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #4781
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->