### PR TITLE
Fix e2e test paths in CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,10 @@ This test files are located in test/programmatic/*
 Behavioral tests are runned by doing:
 
 ```
-$ bash test/pm2_behavior_tests.sh
+$ bash test/e2e.sh
 ```
 
-This test files are located in test/bash/*
+This test files are located in test/e2e/*
 
 ## File of interest
 


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes (documentation bug)
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no, but they don't pass on the development branch for me either
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

This is just a little doc fix, following upon the rename that happened in 8a7db95aabc8437f292af0316cec81ab80ec41f5.