### PR TITLE
Update ProcessContainerFork.js - Fixes Issue #4839

### DIFF
--- a/lib/ProcessContainerFork.js
+++ b/lib/ProcessContainerFork.js
@@ -3,6 +3,7 @@
  * Use of this source code is governed by a license that
  * can be found in the LICENSE file.
  */
+var Url = require('url');
 // Inject custom modules
 var ProcessUtils = require('./ProcessUtils')
 ProcessUtils.injectModules()
@@ -26,7 +27,7 @@ if (process.connected &&
 // Require the real application
 if (process.env.pm_exec_path) {
   if (ProcessUtils.isESModule(process.env.pm_exec_path) === true) {
-    import(process.env.pm_exec_path);
+    import(Url.pathToFileURL(process.env.pm_exec_path));
   }
   else
     require('module')._load(process.env.pm_exec_path, null, true);


### PR DESCRIPTION
This PR fixes critical issue #4839 . Good details have been given in the issue description. Here, I am basically changing line 29 in `lib\ProcessContainerFork.js` that loads ES module scripts to use file URL format instead of the raw path of the referenced script.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes
| Fixed tickets | #4839 
| License       | MIT
