### PR TITLE
Fix TypeScript error callback types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -433,9 +433,9 @@ interface ReloadOptions {
 type ProcessStatus = 'online' | 'stopping' | 'stopped' | 'launching' | 'errored' | 'one-launch-status';
 type Platform = 'ubuntu' | 'centos' | 'redhat' | 'gentoo' | 'systemd' | 'darwin' | 'amazon';
 
-type ErrCallback = (err: Error) => void;
-type ErrProcCallback = (err: Error, proc: Proc) => void;
-type ErrProcDescCallback = (err: Error, processDescription: ProcessDescription) => void;
-type ErrProcDescsCallback = (err: Error, processDescriptionList: ProcessDescription[]) => void;
-type ErrResultCallback = (err: Error, result: any) => void;
-type ErrBusCallback = (err: Error, bus: any) => void;
+type ErrCallback = (err: Error | null) => void;
+type ErrProcCallback = (err: Error | null, proc: Proc) => void;
+type ErrProcDescCallback = (err: Error | null, processDescription: ProcessDescription) => void;
+type ErrProcDescsCallback = (err: Error | null, processDescriptionList: ProcessDescription[]) => void;
+type ErrResultCallback = (err: Error | null, result: any) => void;
+type ErrBusCallback = (err: Error | null, bus: any) => void;


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

`Error` will not always exist and can be `null`.

With regards to BC, anyone using TypeScript and PM2 will already be using something like `if(err) {…}` so it should be fine.