### PR TITLE
Fix: filter_env not work when use {filter_env:true}

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -193,20 +193,20 @@ Common.prepareAppConf = function(opts, app) {
     if (app.filter_env == true)
       return {}
 
-    if (typeof app.filter_env === 'string') {
-      delete envObj[app.filter_env]
-      return envObj
+    var filter_env = app.filter_env;
+    if (typeof filter_env === 'string') {
+      filter_env = [filter_env];
     }
 
     var new_env = {};
-    var allowedKeys = app.filter_env.reduce((acc, current) =>
+    var allowedKeys = filter_env.reduce((acc, current) =>
                                             acc.filter( item => !item.includes(current)), Object.keys(envObj))
     allowedKeys.forEach( key => new_env[key] = envObj[key]);
     return new_env
   }
 
   app.env = [
-    {}, (app.filter_env && app.filter_env.length > 0) ? filterEnv(process.env) : env, app.env || {}
+    {}, app.filter_env ? filterEnv(process.env) : env, app.env || {}
   ].reduce(function(e1, e2){
     return util._extend(e1, e2);
   });

--- a/test/programmatic/filter_env.mocha.js
+++ b/test/programmatic/filter_env.mocha.js
@@ -34,10 +34,25 @@ describe('API checks', function() {
     })
   })
 
-  it('should start app with filtered env wth array of env to be ignored', function(done) {
+  it('should start app with filtered env with array of env to be ignored', function(done) {
     PM2.start({
       script: './../fixtures/echo.js',
       filter_env: ['SHOULD_NOT_BE_THERE']
+    }, (err) => {
+      should(err).be.null()
+      PM2.list(function(err, list) {
+        should(err).be.null()
+        should(list.length).eql(1)
+        should.not.exists(list[0].pm2_env.SHOULD_NOT_BE_THERE)
+        done()
+      })
+    })
+  })
+
+  it('should start app with filtered env at true to drop all local env', function(done) {
+    PM2.start({
+      script: './../fixtures/echo.js',
+      filter_env: true
     }, (err) => {
       should(err).be.null()
       PM2.list(function(err, list) {
@@ -64,10 +79,10 @@ describe('API checks', function() {
     })
   })
 
-  it('should start app with filtered env at true to drop all local env', function(done) {
+  it('should start app with filtered env with substring env name to be ignored', function(done) {
     PM2.start({
       script: './../fixtures/echo.js',
-      filter_env: true
+      filter_env: '_NOT_BE_'
     }, (err) => {
       should(err).be.null()
       PM2.list(function(err, list) {


### PR DESCRIPTION
filter_env not work when use {filter_env:true}; {filter_env:somestring} should not change process.env

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->