### PR TITLE
Update systeminformation package to 4.27.11 (CVE-2020-7752)

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "should": "^13"
   },
   "optionalDependencies": {
-    "systeminformation": "^4.23.3"
+    "systeminformation": "^4.27.11"
   },
   "bugs": {
     "url": "https://github.com/Unitech/pm2/issues"


### PR DESCRIPTION
Related vulnerability: https://github.com/advisories/GHSA-94xh-2fmc-xf5j

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->