### PR TITLE
App logs from monitor will not be deleted on selecting a different app

### DIFF
--- a/lib/API/Dashboard.js
+++ b/lib/API/Dashboard.js
@@ -74,7 +74,6 @@ Dashboard.init = function() {
   });
 
   this.list.on('select item', (item, i) => {
-    this.logLines = []
     this.logBox.clearItems()
   })
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes
| Fixed tickets | #4923
| License       | MIT

I have encountered this issue when the logs from Log box in monitor/dashboard are lost upon changing the selected app. Upon further research, it seems others had this problem as well for some time now. Upon testing, now the logs are preserved on changing between apps monitored, as expected.