### PR TITLE
Bump systeminformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "semver": "^7.2",
     "source-map-support": "0.5.19",
     "sprintf-js": "1.1.2",
+    "systeminformation": "^5.4.0",
     "vizion": "2.2.1",
     "yamljs": "0.3.0"
   },
@@ -202,7 +203,7 @@
     "should": "^13"
   },
   "optionalDependencies": {
-    "systeminformation": "^4.32"
+    "systeminformation": "^5.4.0"
   },
   "bugs": {
     "url": "https://github.com/Unitech/pm2/issues"


### PR DESCRIPTION
I've noticed about a moderate vulnerability in [systeminformation package](https://www.npmjs.com/package/systeminformation):

![image](https://user-images.githubusercontent.com/13206817/109038173-39225000-76aa-11eb-9572-6712155d0af9.png)

This pull request aims to solve this problem:

![image](https://user-images.githubusercontent.com/13206817/109038651-b64dc500-76aa-11eb-9abe-81f4964c51e9.png)

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | https://www.npmjs.com/advisories/1628
<!--
*Please update this template with something that matches your PR*
-->