### PR TITLE
fix: Clear timer before exit  (#5013)

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -327,6 +327,12 @@ God.executeApp = function executeApp(env, cb) {
         if (clu.connected === true)
           clu.disconnect && clu.disconnect();
         clu._reloadLogs = null;
+        if (clu.pm2_env.wait_ready && ready_timeout) {
+          clearTimeout(ready_timeout);
+          ready_timeout = null
+          God.bus.removeListener('process:msg', listener)
+          readyCb(clu);
+        }
         return God.handleExit(clu, code || 0, signal);
       });
 
@@ -335,6 +341,7 @@ God.executeApp = function executeApp(env, cb) {
 
       // Timeout if the ready message has not been sent before listen_timeout
       var ready_timeout = setTimeout(function() {
+        ready_timeout = null
         God.bus.removeListener('process:msg', listener)
         return readyCb(clu)
       }, clu.pm2_env.listen_timeout || cst.GRACEFUL_LISTEN_TIMEOUT);
@@ -344,6 +351,7 @@ God.executeApp = function executeApp(env, cb) {
             packet.process.name === clu.pm2_env.name &&
             packet.process.pm_id === clu.pm2_env.pm_id) {
           clearTimeout(ready_timeout);
+          ready_timeout = null
           God.bus.removeListener('process:msg', listener)
           return readyCb(clu)
         }


### PR DESCRIPTION
In “wait_ready“ mode, ready_timeout may be triggered after the process stops
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5013,#4355
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->