### PR TITLE
Document breaking changes in 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ pm2 set pm2:sysmonit true
 
 Data quantity sent from PM2 to PM2.io has been reduced by 80%, thanks for a json patch differential system. Much more data can now be exposed (metrics, actions) to PM2.io
 
+### Breaking changes
+- drop support for node 8.x and 10.x
+
 ### Other fixes
 
 - feat: added args and full script path to monitoring data


### PR DESCRIPTION
Clearly state in changelog file that node 8.x and 10.x are not supported anymore, as it is mentioned in README.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->