### PR TITLE
Add missing property `args` to the type declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
   <i>Runtime Edition</i>
 <br/><br/>
 
-<a href="https://npm-stat.com/charts.html?package=pm2&from=2015-10-09" title="PM2 Downloads">
+<a title="PM2 Downloads">
   <img src="https://img.shields.io/npm/dm/pm2" alt="Downloads per Month"/>
 </a>
 
-<a href="https://npm-stat.com/charts.html?package=pm2&from=2015-10-09" title="PM2 Downloads">
+<a title="PM2 Downloads">
   <img src="https://img.shields.io/npm/dy/pm2" alt="Downloads per Year"/>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <i>Runtime Edition</i>
 <br/><br/>
 
+  
 <a title="PM2 Downloads">
   <img src="https://img.shields.io/npm/dm/pm2" alt="Downloads per Month"/>
 </a>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
    <img src="https://badge.fury.io/js/pm2.svg" alt="npm version">
 </a>
 
-<a href="https://travis-ci.org/Unitech/pm2" title="PM2 Tests">
+<a href="https://travis-ci.com/github/Unitech/pm2" title="PM2 Tests">
   <img src="https://travis-ci.org/Unitech/pm2.svg?branch=master" alt="Build Status"/>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,7 @@ With NPM:
 $ npm install pm2 -g
 ```
 
-Or if you don't have Node.js installed:
-
-```bash
-wget -qO- https://getpm2.com/install.sh | bash
-```
+You can install Node.js easily with [NVM](https://riptutorial.com/node-js/example/4578/using-node-version-manager--nvm-) or [ASDF](https://blog.natterstefan.me/how-to-use-multiple-node-version-with-asdf)
 
 ### Start an application
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -302,6 +302,10 @@ interface Pm2Env {
    * The path of the script being run in this process.
    */
   pm_exec_path?: string;
+  /**
+   * The arguments passed to the executable
+   */
+  args?: string;
 }
 
 export interface StartOptions {


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

I'm leveraging `args` in my app and TypeScript is throwing an error for this missing prop.