### PR TITLE
fix(lib/API): --ext not work with --ignore-watch

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -721,7 +721,7 @@ class API {
     var mas = [];
     if(typeof opts.ext != 'undefined')
       hf.make_available_extension(opts, mas); // for -e flag
-    mas.length > 0 ? app_conf.ignore_watch = mas : 0;
+    mas.length > 0 ? app_conf.ignore_watch = mas.concat(app_conf.ignore_watch || []) : 0;
 
     /**
      * If -w option, write configuration to configuration.json file


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

pm2 `--ext` option not work with `--ignore-watch`, for example below, expected change js files in `server/public` folder not trigger restart, but the fact is it will restart, because of ext override the ignore-watch.
```bash
pm2 start server/app.js --watch --ignore-watch server/public --ext js
```