### PR TITLE
Ensure directory exists before writing to it

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -275,6 +275,7 @@ module.exports = function(CLI) {
       template = getTemplate('launchd');
       destination = path.join(process.env.HOME, 'Library/LaunchAgents/' + launchd_service_name + '.plist');
       commands = [
+        'mkdir -p ' + path.join(process.env.HOME, 'Library/LaunchAgents'),
         'launchctl load -w ' + destination
       ]
       break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5193
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

Ensures the directory `~/Library/LaunchAgents` exists before attempting to write a file to it. Fixes #5193 