### PR TITLE
Removes Deprecated --web option help from PM2-Runtime

### DIFF
--- a/lib/binaries/Runtime.js
+++ b/lib/binaries/Runtime.js
@@ -18,7 +18,6 @@ commander.version(pkg.version)
   .description('pm2-runtime is an automatic pmx injection that runs in simulated no-daemon environment')
   .option('--auto-manage', 'keep application online after command exit')
   .option('--fast-boot', 'boot app faster by keeping pm2 runtime online in background (effective at second exit/start)')
-  .option('--web [port]', 'launch process web api on [port] default to 9615')
   .option('--secret [key]', 'PM2 plus secret key')
   .option('--public [key]', 'PM2 plus public key')
   .option('--machine-name [name]', 'PM2 plus machine name')
@@ -37,10 +36,6 @@ commander.command('*')
     });
 
     pm2.connect(function() {
-      if (commander.web) {
-        var port = commander.web === true ? cst.WEB_PORT : commander.web;
-        pm2.web(port);
-      }
 
       pm2.start(cmd, commander, function(err, obj) {
         if (process.env.PM2_RUNTIME_DEBUG) {

--- a/lib/binaries/Runtime4Docker.js
+++ b/lib/binaries/Runtime4Docker.js
@@ -32,7 +32,6 @@ commander.version(pkg.version)
   .option('--formatted', 'formatted log output |id|app|log')
   .option('--json', 'output logs in json format')
   .option('--delay <seconds>', 'delay start of configuration file by <seconds>', 0)
-  .option('--web [port]', 'launch process web api on [port] (default to 9615)')
   .option('--only <application-name>', 'only act on one application of configuration')
   .option('--no-auto-exit', 'do not exit if all processes are errored/stopped or 0 apps launched')
   .option('--env [name]', 'inject env_[name] env variables in process config file')
@@ -111,11 +110,6 @@ var Runtime = {
           return cb(err);
         if (obj && obj.length == 0)
           return cb(new Error(`0 application started (no apps to run on ${cmd})`))
-
-        if (commander.web) {
-          var port = commander.web === true ? cst.WEB_PORT : commander.web;
-          Runtime.pm2.web(port);
-        }
 
         if (commander.autoExit) {
           setTimeout(function() {


### PR DESCRIPTION
pm2 --web function was removed in v4.0.0 from pm2-runtime

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

The `--web` has not been supported by **pm2-runtime** since version v4.0, this removes confusing language from Runtime files. Can verify by checking `API/Extras.js`. 

Also suggest removing the documentation which references the `--web` flag at https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/