### PR TITLE
fix: stop_exit_codes not being checked

### DIFF
--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -358,5 +358,9 @@
   "io": {
     "type": "object",
     "docDescription": "Specify apm values and configuration"
+  },
+  "stop_exit_codes": {
+    "type": "array",
+    "docDescription": "Restart except on these codes"
   }
 }

--- a/lib/God.js
+++ b/lib/God.js
@@ -395,7 +395,11 @@ God.handleExit = function handleExit(clu, exit_code, kill_signal) {
       debug('Error when unlinking pid file', e);
     }
   }
-
+  if(Array.isArray(proc.pm2_env.stop_exit_codes)
+    && proc.pm2_env.stop_exit_codes.length
+    && proc.pm2_env.stop_exit_codes.includes(exit_code)) {
+    stopping = true;
+  }
   /**
    * Avoid infinite reloop if an error is present
    */


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

Fixes the use of stop_exit_codes attribute sent in env