### PR TITLE
Fix: #5266 - Find the nearest package.json

### DIFF
--- a/lib/ProcessUtils.js
+++ b/lib/ProcessUtils.js
@@ -25,6 +25,18 @@ module.exports = {
     var semver = require('semver')
     var data
 
+    var findPackageJson = function(directory) {
+      var file = path.join(directory, 'package.json')
+      if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+        return file;
+      }
+      var parent = path.resolve(directory, '..')
+      if (parent === directory) {
+        return null;
+      }
+      return findPackageJson(parent)
+    }
+
     if (semver.satisfies(process.version, '< 13.3.0'))
       return false
 
@@ -32,22 +44,12 @@ module.exports = {
       return true
 
     try {
-      data = JSON.parse(fs.readFileSync(path.join(path.dirname(exec_path), 'package.json')))
+      data = JSON.parse(fs.readFileSync(findPackageJson(path.dirname(exec_path))))
       if (data.type === 'module')
         return true
       else
         return false
     } catch(e) {
-    }
-
-    try {
-      data = JSON.parse(fs.readFileSync(path.join(path.dirname(exec_path), '..', 'package.json')))
-      if (data.type === 'module')
-        return true
-      else
-        return false
-    } catch(e) {
-      return false
     }
   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5266
| License       | MIT

I created a [CodeSandbox](https://codesandbox.io/s/gracious-mccarthy-4dnmu) with the fixed issue (the one with the problem can be found on the [original issue](https://github.com/Unitech/pm2/issues/5266) or [HERE](https://codesandbox.io/s/focused-star-5u0qb)).

In a new terminal, you can run `npm run start1` or `npm run start2`. 
Both of them should locate the `package.json` and identify `server.js` as an ESModule correctly