### PR TITLE
fix: make tarball module uninstall cross-platform

### DIFF
--- a/lib/API/Modules/TAR.js
+++ b/lib/API/Modules/TAR.js
@@ -3,7 +3,8 @@ var Configuration = require('../../Configuration.js');
 var cst = require('../../../constants.js');
 var Common = require('../../Common');
 var forEachLimit  = require('async/forEachLimit');
-const sexec = require('../../tools/sexec.js')
+const sexec = require('../../tools/sexec.js');
+const deleteFolderRecursive = require('../../tools/deleteFolderRecursive.js');
 
 var path = require('path');
 var fs = require('fs');
@@ -108,7 +109,7 @@ function installLocal(PM2, module_filepath, opts, cb) {
 
 function deleteModulePath(module_name) {
   var sanitized = module_name.replace(/\./g, '')
-  execSync(`rm -r ${path.join(cst.DEFAULT_MODULE_PATH, module_name)}`, { silent: true })
+  deleteFolderRecursive(path.join(cst.DEFAULT_MODULE_PATH, module_name));
 }
 
 function runInstall(PM2, target_path, module_name, opts, cb) {


### PR DESCRIPTION
On Windows, uninstalling a tarball module fails because pm2 execs `rm -r` which is not available on Windows. This fix replaces the call to `rm` with a call to the existing `deleteFolderRecursive` utility func.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->