### PR TITLE
Fix unnecessary "ENOENT" console.error when serving a spa

### DIFF
--- a/lib/API/Serve.js
+++ b/lib/API/Serve.js
@@ -272,7 +272,7 @@ function serveFile(uri, request, response) {
 
   fs.readFile(filePath, function (error, content) {
     if (error) {
-      if ((!options.spa || request.wantHomepage)) {
+      if ((!options.spa || file === options.homepage)) {
         console.error('[%s] Error while serving %s with content-type %s : %s',
                       new Date(), filePath, contentType, error.message || error);
       }


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5117 
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->