### PR TITLE
fix: used env variable instead of hardcode datetime format

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -98,7 +98,7 @@ var Utility = module.exports = {
     if (cst.PM2_LOG_DATE_FORMAT && typeof cst.PM2_LOG_DATE_FORMAT == 'string') {
       // Generate timestamp prefix
       function timestamp(){
-        return `${dayjs(Date.now()).format('YYYY-MM-DDTHH:mm:ss')}:`;
+        return `${dayjs(Date.now()).format(cst.PM2_LOG_DATE_FORMAT)}:`;
       }
 
       var hacks = ['info', 'log', 'error', 'warn'], consoled = {};


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | possible?
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
I think it is a mistake that the variable cst.PM2_LOG_DATE_FORMAT is checked, but after that it is not used. Instead the format for log date is hardcoded
-->