### PR TITLE
Fix: #5266 - Add default return on error

### DIFF
--- a/lib/ProcessUtils.js
+++ b/lib/ProcessUtils.js
@@ -50,6 +50,7 @@ module.exports = {
       else
         return false
     } catch(e) {
+      return false
     }
   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5266
| License       | MIT

### Context
Related Issue: #5266
Related PR: #5267

### Description
I forgot to add the default return when there is an error finding the `package.json`.
