### PR TITLE
Fix: #4839 - changed path format of process.env.pm_exec_path

### DIFF
--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -10,6 +10,7 @@
  */
 
 var p       = require('path');
+var { pathToFileURL } = require('url')
 var cst     = require('../constants');
 var Utility = require('./Utility.js');
 var ProcessUtils = require('./ProcessUtils');
@@ -298,7 +299,7 @@ function exec(script, stds) {
     process.chdir(pm2_env.pm_cwd || process.env.PWD || p.dirname(script));
 
     if (ProcessUtils.isESModule(script) === true)
-      import(process.env.pm_exec_path);
+      import(pathToFileURL(process.env.pm_exec_path));
     else
       require('module')._load(script, null, true);
 


### PR DESCRIPTION
This PR fixes issue for cluster mode in #4839, #5109.
This fix changes the raw path (start with `c:` / `d:` ) to file URL (start with `file://` ) of the referenced script at line `301` (before fix) / `302` (after fix).


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Tests pass?   | yes
| Fixed tickets | #4839, #5109
| License       | MIT