### PR TITLE
chore: bump croner to 4.2, enable cron legacy mode

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -335,11 +335,11 @@ Common.sink.determineCron = function(app) {
   }
 
   if (app.cron_restart) {
-    const Croner = require('croner');
+    const Cron = require('croner');
 
     try {
       Common.printOut(cst.PREFIX_MSG + 'cron restart at ' + app.cron_restart);
-      Croner(app.cron_restart);
+      Cron(app.cron_restart, { legacyMode: true });
     } catch(ex) {
       return new Error(`Cron pattern error: ${ex.message}`);
     }

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -35,7 +35,7 @@ module.exports = function(God) {
     var pm_id = pm2_env.pm_id
     console.log('[PM2][WORKER] Registering a cron job on:', pm_id);
 
-    var job = Cron(pm2_env.cron_restart, function() {
+    var job = Cron(pm2_env.cron_restart, { legacyMode: true }, function() {
       God.restartProcessId({id: pm_id}, function(err, data) {
         if (err)
           console.error(err.stack || err);

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "chokidar": "^3.5.1",
     "cli-tableau": "^2.0.0",
     "commander": "2.15.1",
-    "croner": "~4.1.92",
+    "croner": "~4.2.0",
     "dayjs": "~1.8.25",
     "debug": "^4.3.1",
     "enquirer": "2.3.6",


### PR DESCRIPTION
This is intended for development, but there is no development branch available at the moment, so i point it to master for now.

*   Bump croner from  ~4.1.x to ~4.2.x
*   Enable croner legacyMode, which make expressions behave like "classic" cron when combining day-of-month and day-of-week. See croner feature [#53](https://github.com/Hexagon/croner/issues/53) for more details.
*   Croner export is normally named `Cron`, Changed one occurence of `Croner()` to `Cron()` for consistency.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->