### PR TITLE
PM2 does not restart crashed processes

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -244,7 +244,6 @@ God.executeApp = function executeApp(env, cb) {
 
       clu.once('error', function(err) {
         console.error(err.stack || err);
-        clu.pm2_env.status = cst.ERRORED_STATUS;
         try {
           clu.destroy && clu.destroy();
         }
@@ -302,7 +301,6 @@ God.executeApp = function executeApp(env, cb) {
 
       clu.once('error', function cluError(err) {
         console.error(err.stack || err);
-        clu.pm2_env.status = cst.ERRORED_STATUS;
         try {
           clu.kill && clu.kill();
         }


### PR DESCRIPTION
With `autorestart` set to true, PM2 will restart child processes if they disconnect. However, if the process crashes internally, PM2 will not attempt to restart or replace it, leaving the overall service running with one less process.

In our case, we just upgraded to node 16 and PM2 5.2.0, and are seeing node periodically throw `ERR_IPC_CLOSED` now. We're not sure about the root cause of that error yet, but regardless, we would expect PM2 to either handle that or at least restart the crashed process. Unfortunately, it's doing neither and just letting the process permanently die.

This appears to be because PM2 [marks the process as `ERRORED_STATUS`](https://github.com/TeamGuilded/pm2/blob/master/lib/God.js#L305) in its `error` event handler, and ERRORED_STATUS processes do [not even attempt to restart](https://github.com/TeamGuilded/pm2/blob/master/lib/God.js#L457).

My proposed fix here skips marking the process as ERRORED_STATUS on a single `error` event, instead reserving that status for [repeated crashes](https://github.com/TeamGuilded/pm2/blob/master/lib/God.js#L407-L411). This is the simplest solution, but I'm open to other ideas/approaches here.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->