### PR TITLE
Ensure increment_var value is a Number

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -560,12 +560,12 @@ God.injectVariables = function injectVariables (env, cb) {
         return proc.pm2_env.name === env.name &&
           typeof proc.pm2_env[env.increment_var] !== 'undefined';
       }).map(function (proc) {
-        return proc.pm2_env[env.increment_var];
+        return Number(proc.pm2_env[env.increment_var]);
       }).sort(function (a, b) {
         return b - a;
       })[0];
     // inject a incremental variable
-    var defaut = env.env[env.increment_var] || 0;
+    var defaut = Number(env.env[env.increment_var]) || 0;
     env[env.increment_var] = typeof lastIncrement === 'undefined' ? defaut : lastIncrement + 1;
     env.env[env.increment_var] = env[env.increment_var];
   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4965
| License       | MIT

This ensures the `increment_var` value is coerced into a Number before attempting to perform any math operations on it. Doing so solves an issue where when you pass in a `PORT` variable through the environment rather than through the ecosystem config file, it would be read as a string and incrementing it would append the number to the string rather than actually incrementing it (e.g., `3000` would result in using ports `3000` and `30001`).