### PR TITLE
fix: all cli 'launch' typos

### DIFF
--- a/examples/sourcemap-auto-resolve/API.js
+++ b/examples/sourcemap-auto-resolve/API.js
@@ -150,7 +150,7 @@ API.prototype.connect = function(noDaemon, cb) {
       return cb(err, meta);
 
     // If new pm2 instance has been popped
-    // Lauch all modules
+    // Launch all modules
     Modularizer.launchAll(that, function(err_mod) {
       return cb(err, meta);
     });

--- a/lib/API.js
+++ b/lib/API.js
@@ -182,7 +182,7 @@ class API {
 
       that.launchSysMonitoring(() => {})
       // If new pm2 instance has been popped
-      // Lauch all modules
+      // Launch all modules
       that.launchAll(that, function(err_mod) {
         return cb(err, meta);
       });

--- a/lib/binaries/CLI.js
+++ b/lib/binaries/CLI.js
@@ -881,7 +881,7 @@ commander.command('logs [id|name|namespace]')
   .option('--out', 'only shows standard output')
   .option('--lines <n>', 'output the last N lines, instead of the last 15 by default')
   .option('--timestamp [format]', 'add timestamps (default format YYYY-MM-DD-HH:mm:ss)')
-  .option('--nostream', 'print logs without lauching the log stream')
+  .option('--nostream', 'print logs without launching the log stream')
   .option('--highlight [value]', 'highlights the given value')
   .description('stream logs file. Default stream all logs')
   .action(function(id, cmd) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| License       | MIT

This PR fixes three simple typos consisting of: `lauch` -> `launch`