### PR TITLE
chore: bump chalk from 3.0.0 to 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@pm2/pm2-version-check": "latest",
     "async": "~3.2.0",
     "blessed": "0.1.81",
-    "chalk": "3.0.0",
+    "chalk": "4.1.2",
     "chokidar": "^3.5.3",
     "cli-tableau": "^2.0.0",
     "coffee-script": "^1.12.7",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This PR updates chalk from 3.0.0 to 4.1.2. Chalk 3.0.0 uses the deprecated `__proto__` API, which is also a security vulnerability. While the way its used in chalk does not create a security issue, some runtimes, such as [Deno](https://deno.land/), do not implement it, which creates errors. This also creates problems when using the `--disable-proto` flag with node.

[Chalk v4](https://github.com/chalk/chalk/releases/tag/v4.0.0) has the following breaking changes:
- It requires a minimum node version of 10. `pm2` already mandates a node version of 12 or higher
- It changes the `Level` typescript enum, which `pm2` does not happen to use