### PR TITLE
fix typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -434,7 +434,7 @@ export interface StartOptions {
 
 interface ReloadOptions {
   /**
-   * (Default: false) If true is passed in, pm2 will reload it’s environment from process.env 
+   * (Default: false) If true is passed in, pm2 will reload it’s environment from process.env
    * before reloading your process.
    */
   updateEnv?: boolean;
@@ -446,7 +446,7 @@ type ProcessStatus = 'online' | 'stopping' | 'stopped' | 'launching' | 'errored'
 type Platform = 'ubuntu' | 'centos' | 'redhat' | 'gentoo' | 'systemd' | 'darwin' | 'amazon';
 
 type ErrCallback = (err: Error) => void;
-type ErrProcCallback = (err: Error, proc: Proc) => void;
+type ErrProcCallback = (err: Error, proc: ProcessDescription[]) => void;
 type ErrProcDescCallback = (err: Error, processDescription: ProcessDescription) => void;
 type ErrProcDescsCallback = (err: Error, processDescriptionList: ProcessDescription[]) => void;
 type ErrResultCallback = (err: Error, result: any) => void;


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->

| Q             | A          |
| ------------- | ---------- |
| Bug fix?      | no         |
| New feature?  | no         |
| BC breaks?    | no         |
| Deprecations? | I think so |
| Tests pass?   | ugh yes    |
| Fixed tickets | idk        |
| License       | MIT        |
| Doc PR        | idk        |

<!--
*Please update this template with something that matches your PR*
-->

scenario:

```ts
pm2.start(id, (e, p) => {
  console.log(p);
  // @ts-ignore
  res.json(p.map(fProcDesc));
});
```

output

```js
[
  {
    name: "hook",
    namespace: "default",
    pm_id: 0,
    status: "online",
    restart_time: 3,
    pm2_env: {
      name: "hook",
      namespace: "default",
      pm_id: 0,
      status: "online",
      restart_time: 3,
      env: [Object],
    },
  },
];
```

same thing with `pm2.stop`

fix: the start/stop commands should return the process description