### PR TITLE
Auto flush with bash

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -443,6 +443,9 @@ Common.sink.resolveInterpreter = function(app) {
   if (app.exec_interpreter.indexOf('python') > -1)
     app.env.PYTHONUNBUFFERED = '1'
 
+  if (app.exec_interpreter.indexOf('bash') > -1)
+    app.env.PYTHONUNBUFFERED = '1'
+
   /**
    * Specific installed JS transpilers
    */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm2",
   "preferGlobal": true,
-  "version": "5.2.1",
+  "version": "5.2.2",
   "engines": {
     "node": ">=10.0.0"
   },
@@ -175,7 +175,6 @@
     "chalk": "3.0.0",
     "chokidar": "^3.5.3",
     "cli-tableau": "^2.0.0",
-    "coffee-script": "^1.12.7",
     "commander": "2.15.1",
     "croner": "~4.1.92",
     "dayjs": "~1.11.5",


### PR DESCRIPTION
Python auto flush didn't work when one start the python project with a bash interpreter. So you couldn't see the python stdout on the pm2 logs. Now with this fix, you certainly can.
