### PR TITLE
Fixes pm2 not flushing logs

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -41,21 +41,23 @@ module.exports = function(CLI) {
           fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
           fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
-        else if (l.pm2_env.name === api) {
+        else if (l.pm2_env.pm_id == api || l.pm2_env.name === api) {
           Common.printOut(cst.PREFIX_MSG + 'Flushing:');
-          Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
-          Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
 
-          if (l.pm2_env.pm_log_path &&
-              l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(api)) {
+          if (l.pm2_env.pm_log_path && fs.existsSync(l.pm2_env.pm_log_path)) {
             Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_log_path, 'w'));
           }
 
-          if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api))
+          if (fs.existsSync(l.pm2_env.pm_out_log_path)) {
+            Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
-          if (l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(api))
+          }
+
+          if (fs.existsSync(l.pm2_env.pm_err_log_path)) {
+            Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
+          }
         }
       });
 

--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -41,29 +41,20 @@ module.exports = function(CLI) {
           fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
           fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
-        else if (l.pm2_env.pm_id == api || l.pm2_env.name === api) {
+        else if (l.pm2_env.name === api) {
           Common.printOut(cst.PREFIX_MSG + 'Flushing:');
           Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
           Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
 
-          const regex = /.*\/(.*?)(?:-(?:out|error))?\.log$/;
-          let m;
-
-          if ((m = regex.exec(l.pm2_env.pm_err_log_path)) !== null) {
-            m.forEach((match, grpIndex) => {
-              m = match;
-            });
-          }
-
           if (l.pm2_env.pm_log_path &&
-              l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(m)) {
+              l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(api)) {
             Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_log_path, 'w'));
           }
 
-          if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(m))
+          if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api))
             fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
-          if (l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(m))
+          if (l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(api))
             fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
       });

--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -41,20 +41,29 @@ module.exports = function(CLI) {
           fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
           fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
-        else if (l.pm2_env.name === api) {
+        else if (l.pm2_env.pm_id == api || l.pm2_env.name === api) {
           Common.printOut(cst.PREFIX_MSG + 'Flushing:');
           Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
           Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
 
+          const regex = /.*\/(.*?)(?:-(?:out|error))?\.log$/;
+          let m;
+
+          if ((m = regex.exec(l.pm2_env.pm_err_log_path)) !== null) {
+            m.forEach((match, grpIndex) => {
+              m = match;
+            });
+          }
+
           if (l.pm2_env.pm_log_path &&
-              l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(api)) {
+              l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(m)) {
             Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_log_path, 'w'));
           }
 
-          if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api))
+          if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(m))
             fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
-          if (l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(api))
+          if (l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(m))
             fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pm2",
   "preferGlobal": true,
-  "version": "5.2.1",
+  "version": "5.2.2",
   "engines": {
     "node": ">=10.0.0"
   },
@@ -175,7 +175,6 @@
     "chalk": "3.0.0",
     "chokidar": "^3.5.3",
     "cli-tableau": "^2.0.0",
-    "coffee-script": "^1.12.7",
     "commander": "2.15.1",
     "croner": "~4.1.92",
     "dayjs": "~1.11.5",


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not ran
| Fixed tickets | #5529
| License       | MIT
| Doc PR        | N/A

<h3>What's this PR about?</h3>

This PR aims to fix and restore the ability to use either `pm2 flush <app_id>` or `pm2 flush <app_name>` to flush logs successfully.

<h3>Why so many commits?</h3>

In the first commit of this PR, I used a regex to extract a valid filename from a log path to allow the existing `if-else` comparison to continue working whatever it's intended.

It worked perfectly. Well only if the user didn't seek to customize their logging path or name! Because it's found out later that this solution isn't feasible as it would mean that a log file *must* end with an extension of `.log`, or else the flush will not work.

An example is when a user tries to redirect stderr to a file like `~/myApp/logs/process.error`, the solution will not be able to handle this. Hence, I have chosen to revert the changes made by the first commit.  

<h3>About the latest commit</h3>

Now, about the latest commit of this PR. The printout msg of flushing a log file has been moved inside their respective `if` block. This fixed a problem where users are reporting that the command is printing out the log file message like below even though the logs aren't even getting flushed.

```
[PM2] Flushing:
[PM2] /home/pi/.pm2/logs/My-App-out.log
[PM2] /home/pi/.pm2/logs/My-App-error.log
[PM2] Logs flushed
```

And I don't really get what's this `if-else` trying to accomplish within its logic comparison.

``` javascript
if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api)) {
    <...>
}
```

Anyways, we will be replacing it and use `fs.existsSync(FILE_PATH)` to check whether a log file exists or not. So now, part of the code looks like this:
``` javascript
if (fs.existsSync(l.pm2_env.pm_out_log_path)) {
    Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
    fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
}
```

This solution should be universal enough that it allows the command to flush the logs correctly even though a unique log path has been specified.