### PR TITLE
hotfix: replace non-working condition that blocks flush from clearing the logs

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -41,21 +41,23 @@ module.exports = function(CLI) {
           fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
           fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
-        else if (l.pm2_env.name === api) {
+        else if (l.pm2_env.pm_id == api || l.pm2_env.name === api) {
           Common.printOut(cst.PREFIX_MSG + 'Flushing:');
-          Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
-          Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
 
-          if (l.pm2_env.pm_log_path &&
-              l.pm2_env.pm_log_path.lastIndexOf('/') < l.pm2_env.pm_log_path.lastIndexOf(api)) {
+          if (l.pm2_env.pm_log_path && fs.existsSync(l.pm2_env.pm_log_path)) {
             Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_log_path, 'w'));
           }
 
-          if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api))
+          if (l.pm2_env.pm_out_log_path && fs.existsSync(l.pm2_env.pm_out_log_path)) {
+            Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_out_log_path, 'w'));
-          if (l.pm2_env.pm_err_log_path.lastIndexOf('/') < l.pm2_env.pm_err_log_path.lastIndexOf(api))
+          }
+
+          if (l.pm2_env.pm_err_log_path && fs.existsSync(l.pm2_env.pm_err_log_path)) {
+            Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
             fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
+          }
         }
       });
 


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4553
| License       | MIT
| Doc PR        | N/A

<h3>Changes explanation</h3>

Although the pm2 docs mentioned users can pass <app_id> as an argument to `pm2 flush <...>`, the code doesn't recognize that. So we will be using this instead:

``` javascript
else if (l.pm2_env.pm_id == api || l.pm2_env.name === api) {
    <...>
}
```

Next, in the flush function, the condition to flush a file is depended as below:
``` javascript
if (l.pm2_env.pm_out_log_path.lastIndexOf('/') < l.pm2_env.pm_out_log_path.lastIndexOf(api))
```

The condition is fine, however, when the name of an app has space, the flush command will never succeed.

<h4>Here's why:</h4>

Let's say an app's name is `My Cool Server`, the log file will be created as `<...home_dir...>/.pm2/logs/My-Cool-Server-out.log`.

Take note that any spaces in the app name have been replaced with hyphens (-).

So when a user tries to do `pm2 flush "My Cool Server"`. The condition will be comparing the last occurrence of `/` and `api`.
Since `api` is the argument passed from the user, so the value will be `My Cool Server`.

Now, the value of `l.pm2_env.pm_out_log_path` will be `/home/user/.pm2/logs/My-Cool-Server-out.log`. The `lastIndexOf` func will try to find `My Cool Server` from the log path name. But it will never work because there are hyphens (-) in the filename! Hence, the `if-else` condition is never passed, which is why the flush command doesn't flush the logs!

Hence, it's now replaced with the code below:
``` javascript
if (l.pm2_env.pm_out_log_path && fs.existsSync(FILEPATH))
```

Here, we will check whether the string `l.pm2_env.pm_out_log_path` has any value, then we will use `fs.existsSync()` to check whether the file exists or not. If both returned true, we will then proceed to flush the logs.

-------------------------------

Note: The issues are present in both, the development and stable version of pm2.

<h4>A screenshot of the issue:</h4>

![image](https://user-images.githubusercontent.com/67184263/213644452-f588bf21-ee21-4564-ab6a-0d371377c460.png)

<h4>After applying the fix:</h4>

![image](https://user-images.githubusercontent.com/67184263/213644918-db88cdcb-f3d3-467a-86d1-d8e4c60df552.png)

<h4>Now, it works fine with app_name that has spaces too!</h4>

![image](https://user-images.githubusercontent.com/67184263/213645133-b514066f-c6f2-4546-b479-c5ea5dfe17b2.png)