### PR TITLE
Change package version in process list table

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -474,7 +474,7 @@ God.finalizeProcedure = function finalizeProcedure(proc) {
   var current_path = proc.pm2_env.cwd || path.dirname(proc.pm2_env.pm_exec_path);
   var proc_id      = proc.pm2_env.pm_id;
 
-  proc.pm2_env.version = Utility.findPackageVersion(proc.pm2_env.pm_exec_path || proc.pm2_env.cwd);
+  proc.pm2_env.version = Utility.findPackageVersion(proc.pm2_env.cwd || proc.pm2_env.pm_exec_path);
 
   if (proc.pm2_env.vizion_running === true) {
     debug('Vizion is already running for proc id: %d, skipping this round', proc_id);


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | **yes**
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->
---
By default PM2 look first available `package.json` and it's always `nvm` packet in script path
`/home/develop/.nvm/versions/node/v18.13.0/bin/npm` If we start script like that:
```json
{
  "script": "npm",
  "args": "run start"
}
```
in list process table we always see `nvm` version, now it `0.39.3`
I think it's incorrect, because we need to see started package version

P.S. this [answer](https://stackoverflow.com/a/69078407/16735597) was the source 