### PR TITLE
ls condensed breakpoint env variable

### DIFF
--- a/lib/API/UX/pm2-ls.js
+++ b/lib/API/UX/pm2-ls.js
@@ -9,7 +9,7 @@ const Passwd = require('../../tools/passwd.js')
 
 const List = {}
 
-const CONDENSED_MODE = (process.stdout.columns || 300) < 120
+const CONDENSED_MODE = (process.stdout.columns || 300) < (Number(process.env.PM2_LS_CONDENSED_COLUMN_BREAKPOINT) || 120)
 
 /**
  * Check if dump file contains same apps that the one managed by PM2


### PR DESCRIPTION
PM2's table incorrectly renders on nearly all of my servers because of how much information it displays and my screen doesn't have the width for it.
- It attempts to render the full table even when the screen cannot support it; resulting in an overflow of various bars to the next line.
- I would prefer if we could explicitly hide columns from `pm2 ls`, but a simple environment variable would suffice as a quick fix as condensed mode works great; just doesn't activate when I need it to.

My proposal is to add `PM2_LS_CONDENSED_COLUMN_BREAKPOINT` as an environment variable to specify what value is used to determine if condensed mode should be run (currently `120` is hardcoded). This would let admins define the variable globally for all users to ensure that anyone who runs `pm2 ls` will get the proper display mode.
- I think an overly specific name such as this would be good because it wouldn't conflict with anything else, and it would allow you to explicitly change the behavior of only this single component of PM2.



<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->