### PR TITLE
Fix: #5443 - resume cron rule when resurrect

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -114,6 +114,7 @@ God.prepare = function prepare (env, cb) {
         }
       }
       God.clusters_db[env.pm_id] = clu
+      God.registerCron(env)
       return cb(null, [ God.clusters_db[env.pm_id] ])
     }
 


### PR DESCRIPTION
cron_restart is not working after resurrect


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5443
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls