### PR TITLE
perf: postpone restarting to the last change

### DIFF
--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -51,6 +51,8 @@ module.exports = function ClusterMode(God) {
 
     console.log('[Watch] Start watching', pm2_env.name);
 
+    var timeoutId;
+
     watcher.on('all', function(event, path) {
       var self = this;
 
@@ -63,7 +65,10 @@ module.exports = function ClusterMode(God) {
 
       console.log('Change detected on path %s for app %s - restarting', path, pm2_env.name);
 
-      setTimeout(function() {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      timeoutId = setTimeout(function() {
         God.restartProcessName(pm2_env.name, function(err, list) {
           self.restarting = false;
 


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

This pull request improves server performance by optimizing the restart process. Instead of restarting the server each time a change occurs, the system will now wait until the last change within the specified watch_delay time window before restarting. This approach reduces server downtime and improves overall system efficiency.