### PR TITLE
Serve/SPA: readFile returns EISDIR instead of ENOENT when a directory is called

### DIFF
--- a/lib/API/Serve.js
+++ b/lib/API/Serve.js
@@ -271,7 +271,7 @@ function serveFile(uri, request, response) {
                       new Date(), filePath, contentType, error.message || error);
       }
       errorMeter.mark();
-      if (error.code === 'ENOENT') {
+      if (error.code === 'ENOENT' || error.code === 'EISDIR') {
         if (options.spa && !request.wantHomepage) {
           request.wantHomepage = true;
           return serveFile(`/${path.basename(file)}`, request, response);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

When http://locahost:3000/category/tutorial---basics (Docusaurus example) is called, readFile returns EISDIR instead of ENOENT so the error "Sorry, check with the site admin for error: EISDIR" is showed