### PR TITLE
Fix matching logic for logs from namespace when lines = 0

### DIFF
--- a/lib/API/Log.js
+++ b/lib/API/Log.js
@@ -98,9 +98,11 @@ Log.stream = function(Client, id, raw, timestamp, exclusive, highlight) {
     var min_padding = 3
 
     bus.on('log:*', function(type, packet) {
-      if (id !== 'all'
-          && packet.process.name != id
-          && packet.process.pm_id != id)
+      var isMatchingProcess = id === 'all'
+        || packet.process.name === id
+        || packet.process.pm_id === id
+        || packet.process.namespace === id;
+      if (!isMatchingProcess)
         return;
 
       if ((type === 'out' && exclusive === 'err')

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -92,6 +92,7 @@ runTest ./test/e2e/logs/log-entire.sh
 runTest ./test/e2e/logs/log-null.sh
 runTest ./test/e2e/logs/log-json.sh
 runTest ./test/e2e/logs/log-create-not-exist-dir.sh
+runTest ./test/e2e/logs/log-namespace.sh
 
 # MODULES
 runTest ./test/e2e/modules/get-set.sh

--- a/test/e2e/logs/log-namespace.sh
+++ b/test/e2e/logs/log-namespace.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+SRC=$(cd $(dirname "$0"); pwd)
+source "${SRC}/../include.sh"
+
+cd $file_path/log-namespace/
+
+LOG_PATH_PREFIX="${SRC}/__log-namespace__"
+
+rm -rf "${LOG_PATH_PREFIX}"
+mkdir "${LOG_PATH_PREFIX}"
+
+$pm2 start echo.js --namespace e2e-test-log-namespace
+
+LOG_FILE_BASELINE="${LOG_PATH_PREFIX}/baseline-out.log"
+$pm2 logs e2e-test-log-namespace > $LOG_FILE_BASELINE & # backgrounded - will be stopped by `$pm2 delete all`
+
+sleep 2 # should leave time for ~40 "tick" lines
+
+# Using -q to avoid spamming, since there will be a fair few "tick" matches
+grep -q "tick" ${LOG_FILE_BASELINE}
+spec "Should have 'tick' in the log file"
+
+LOG_FILE_LINES_ZERO="${LOG_PATH_PREFIX}/lines-zero-out.log"
+$pm2 logs e2e-test-log-namespace --lines 0 > $LOG_FILE_LINES_ZERO &
+
+sleep 2 # should leave time for ~40 "tick" lines
+
+# Using -q to avoid spamming, since there will be a fair few "tick" matches
+grep -q "tick" ${LOG_FILE_LINES_ZERO}
+spec "Should have 'tick' in the log file even if using --lines 0"
+
+cd ${SRC}
+rm -rf "${LOG_PATH_PREFIX}"
+$pm2 delete all

--- a/test/fixtures/log-namespace/echo.js
+++ b/test/fixtures/log-namespace/echo.js
@@ -1,0 +1,4 @@
+console.log("start");
+setInterval(function () {
+  console.log("tick");
+}, 50);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5658
| License       | MIT
| Doc PR        | N/A (?)

