### PR TITLE
Upgrade @pm2/agent to remove vulnerable vm2 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </a>
 
 <a href="https://travis-ci.com/github/Unitech/pm2" title="PM2 Tests">
-  <img src="https://travis-ci.org/Unitech/pm2.svg?branch=master" alt="Build Status"/>
+  <img src="https://travis-ci.com/Unitech/pm2.svg?branch=master" alt="Build Status"/>
 </a>
 
 <br/>

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "pm2-runtime": "bin/pm2-runtime"
   },
   "dependencies": {
-    "@pm2/agent": "~2.0.0",
+    "@pm2/agent": "~2.0.3",
     "@pm2/io": "~5.0.0",
     "@pm2/js-api": "~0.6.7",
     "@pm2/pm2-version-check": "latest",


### PR DESCRIPTION
`vm2` has critical vulnerability: https://security.snyk.io/vuln/SNYK-JS-VM2-5772823

Dependency chain: 
pm2 > @pm2/agent > proxy-agent > pac-proxy-agent > pac-resolver > degenerator > vm2

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1234, #5678
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls