### PR TITLE
fix: pm2 not using kill_retry_time from config file

### DIFF
--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -357,7 +357,7 @@
   },
   "kill_retry_time": {
     "type": "number",
-    "default" : 100
+    "docDefault" : 100
   },
   "write": {
     "type": "boolean"


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
