### PR TITLE
Fix bug with namespace when logs command run before start

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -161,7 +161,6 @@ module.exports = function(CLI) {
     // Get the list of all running apps
     that.Client.executeRemote('getMonitorData', {}, function(err, list) {
       var regexList = [];
-      var namespaceList = [];
 
       if (err) {
         Common.printError(err);
@@ -190,9 +189,6 @@ module.exports = function(CLI) {
               type     : 'err'
             });
         } else if(proc.pm2_env && proc.pm2_env.namespace == id) {
-          if(namespaceList.indexOf(proc.pm2_env.name) === -1) {
-            namespaceList.push(proc.pm2_env.name)
-          }
           if (proc.pm2_env.pm_out_log_path && exclusive !== 'err')
             pushIfUnique({
               path     : proc.pm2_env.pm_out_log_path,
@@ -251,12 +247,8 @@ module.exports = function(CLI) {
                 Log.stream(that.Client, id, raw, timestamp, exclusive, highlight);
             })
           }
-          else if(namespaceList.length > 0) {
-            namespaceList.forEach(function(id) {
-                Log.stream(that.Client, id, raw, timestamp, exclusive, highlight);
-            })
-          }
           else {
+            // Internally Log.stream handles `id` being a name, id, or namespace just fine
             Log.stream(that.Client, id, raw, timestamp, exclusive, highlight);
           }
         });

--- a/test/e2e/logs/log-namespace.sh
+++ b/test/e2e/logs/log-namespace.sh
@@ -10,6 +10,9 @@ LOG_PATH_PREFIX="${SRC}/__log-namespace__"
 rm -rf "${LOG_PATH_PREFIX}"
 mkdir "${LOG_PATH_PREFIX}"
 
+# The first operation that starts the daemon needs to be in the foreground, otherwise we risk starting multiple
+$pm2 ping
+
 LOG_FILE_PREMATURE="${LOG_PATH_PREFIX}/premature-log-out.log"
 $pm2 logs e2e-test-log-namespace > $LOG_FILE_PREMATURE & # backgrounded - will be stopped by `$pm2 delete all`
 

--- a/test/e2e/logs/log-namespace.sh
+++ b/test/e2e/logs/log-namespace.sh
@@ -10,6 +10,9 @@ LOG_PATH_PREFIX="${SRC}/__log-namespace__"
 rm -rf "${LOG_PATH_PREFIX}"
 mkdir "${LOG_PATH_PREFIX}"
 
+LOG_FILE_PREMATURE="${LOG_PATH_PREFIX}/premature-log-out.log"
+$pm2 logs e2e-test-log-namespace > $LOG_FILE_PREMATURE & # backgrounded - will be stopped by `$pm2 delete all`
+
 $pm2 start echo.js --namespace e2e-test-log-namespace
 
 LOG_FILE_BASELINE="${LOG_PATH_PREFIX}/baseline-out.log"
@@ -20,6 +23,8 @@ sleep 2 # should leave time for ~40 "tick" lines
 # Using -q to avoid spamming, since there will be a fair few "tick" matches
 grep -q "tick" ${LOG_FILE_BASELINE}
 spec "Should have 'tick' in the log file"
+grep -q "tick" ${LOG_FILE_PREMATURE}
+spec "Should have 'tick' in the log file even if 'log' called before 'start'"
 
 LOG_FILE_LINES_ZERO="${LOG_PATH_PREFIX}/lines-zero-out.log"
 $pm2 logs e2e-test-log-namespace --lines 0 > $LOG_FILE_LINES_ZERO &


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5788
| License       | MIT
| Doc PR        | 

I created the ticket linked above, and this is my attempt at a fix.

This implementation is something my company has been using (via `pnpm patch`) for a few months now to good effect. Others might benefit from it too.

I tried to do something similar to what I did in my past PR (#5660), since that one seemed rather painless.