### PR TITLE
feat: add app launch in parallel limit

### DIFF
--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -148,6 +148,11 @@
     "docDefault": false,
     "docDescription": "Make the process wait for a process.send('ready')"
   },
+  "launch_limit": {
+    "type": "number",
+    "docDefault": 1,
+    "docDescription": "Maximum number of launching processes at a time"
+  },
   "instances": {
     "type": "number",
     "docDefault": 1,

--- a/lib/God.js
+++ b/lib/God.js
@@ -136,7 +136,14 @@ God.prepare = function prepare (env, cb) {
     env.instances = 1;
   }
 
-  timesLimit(env.instances, 1, function (n, next) {
+  // app launch in parallel limit
+  if (env.launch_limit != null) {
+    env.launch_limit = parseInt(env.launch_limit);
+  }
+  if (!env.launch_limit || env.launch_limit < 0) {
+    env.launch_limit = 1;
+  }
+  timesLimit(env.instances, env.launch_limit, function (n, next) {
     env.vizion_running = false;
     if (env.env && env.env.vizion_running) {
       env.env.vizion_running = false;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -384,6 +384,10 @@ export interface StartOptions {
    */
   wait_ready?: boolean;
   /**
+   * (Default: 1) Maximum number of launching processes at a time on application startup.
+   */
+  launch_limit?: number;
+  /**
    * (Default: 1600)
    * The number of milliseconds to wait after a stop or restart command issues a SIGINT signal to kill the
    * script forceably with a SIGKILL signal.
@@ -446,7 +450,7 @@ export interface StartOptions {
 
 interface ReloadOptions {
   /**
-   * (Default: false) If true is passed in, pm2 will reload it’s environment from process.env 
+   * (Default: false) If true is passed in, pm2 will reload it’s environment from process.env
    * before reloading your process.
    */
   updateEnv?: boolean;


### PR DESCRIPTION
In my app, I use a 'wait ready' event during app startup. Starting one instance takes 1 minute (with high CPU usage during app initialization), and starting all instances takes 6 minutes. Using a 'launch in parallel limit' config could reduce the app's startup time, and CPU usage would be more efficient during the startup phase.

| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
