### PR TITLE
fix: deprecated warning util.isArray

### DIFF
--- a/examples/sourcemap-auto-resolve/API.js
+++ b/examples/sourcemap-auto-resolve/API.js
@@ -299,7 +299,7 @@ API.prototype.start = function(cmd, opts, cb) {
 
   var that = this;
 
-  if (util.isArray(opts.watch) && opts.watch.length === 0)
+  if (Array.isArray(opts.watch) && opts.watch.length === 0)
     opts.watch = (opts.rawArgs ? !!~opts.rawArgs.indexOf('--watch') : !!~process.argv.indexOf('--watch')) || false;
 
   if (Common.isConfigFile(cmd) || (typeof(cmd) === 'object'))
@@ -1401,7 +1401,7 @@ API.prototype._handleAttributeUpdate = function(opts) {
 
   delete appConf.exec_mode;
 
-  if (util.isArray(appConf.watch) && appConf.watch.length === 0) {
+  if (Array.isArray(appConf.watch) && appConf.watch.length === 0) {
     if (!~opts.rawArgs.indexOf('--watch'))
       delete appConf.watch
   }

--- a/lib/API.js
+++ b/lib/API.js
@@ -322,7 +322,7 @@ class API {
     if (!opts) opts = {};
 
     var that = this;
-    if (util.isArray(opts.watch) && opts.watch.length === 0)
+    if (Array.isArray(opts.watch) && opts.watch.length === 0)
       opts.watch = (opts.rawArgs ? !!~opts.rawArgs.indexOf('--watch') : !!~process.argv.indexOf('--watch')) || false;
 
     if (Common.isConfigFile(cmd) || (typeof(cmd) === 'object')) {
@@ -1611,7 +1611,7 @@ class API {
 
     delete appConf.exec_mode;
 
-    if (util.isArray(appConf.watch) && appConf.watch.length === 0) {
+    if (Array.isArray(appConf.watch) && appConf.watch.length === 0) {
       if (!~opts.rawArgs.indexOf('--watch'))
         delete appConf.watch
     }

--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -4,7 +4,6 @@
  * can be found in the LICENSE file.
  */
 var chokidar = require('chokidar');
-var util     = require('util');
 var log      = require('debug')('pm2:watch');
 
 module.exports = function ClusterMode(God) {
@@ -29,7 +28,7 @@ module.exports = function ClusterMode(God) {
 
     var watch = pm2_env.watch
 
-    if(typeof watch == 'boolean' || util.isArray(watch) && watch.length === 0)
+    if(typeof watch == 'boolean' || Array.isArray(watch) && watch.length === 0)
       watch = pm2_env.pm_cwd;
 
     log('Watching %s', watch);


### PR DESCRIPTION
A fixed deprecation warning in Node.js 22
```bash
(node:56912) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
```
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->