### PR TITLE
fix: env output in pm2-describe

### DIFF
--- a/lib/API/UX/pm2-describe.js
+++ b/lib/API/UX/pm2-describe.js
@@ -176,7 +176,10 @@ module.exports = function(proc) {
   Object.keys(diff_env).forEach(function(key) {
     var obj = {}
     if (_env[key]) {
-      obj[key] = _env[key].slice(0, process.stdout.columns - 60)
+      // 1. fix env value is not a String and slice is undeinfed
+      // 2. fix process.stdout.columns is undefined and causes empty string output
+      // 3. columns defaults to 300 - same as specified in pm2-ls
+      obj[key] = String(_env[key]).slice(0, (process.stdout.columns || 300) - 60)
       UxHelpers.safe_push(table_env, obj)
     }
   })


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5832
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

### Situation

envs like `vizion_running` and `vizion_running` are Boolean not String. See:
https://github.com/search?q=repo%3AUnitech%2Fpm2+%22env.vizion_running%22&type=code
https://github.com/search?q=repo%3AUnitech%2Fpm2%20%22env.updateEnv%22&type=code

### Before the fix

<img width="1135" alt="image" src="https://github.com/Unitech/pm2/assets/6647633/d7d9d609-b6c2-47c4-8b27-61782c6bba6a">

### After the fix

<img width="743" alt="image" src="https://github.com/Unitech/pm2/assets/6647633/a236c5ed-7633-4273-85a2-83438c94e3e4">
