### PR TITLE
Fix autostart: false

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -186,6 +186,7 @@ God.executeApp = function executeApp(env, cb) {
    * 2 - Reset restart time and unstable_restarts
    * 3 - Assign a log file name depending on the id
    * 4 - If watch option is set, look for changes
+   * 5 - If autostart option is false, skip process start
    */
   if (env_copy['pm_id'] === undefined) {
     env_copy['pm_id']             = God.getNewId();
@@ -207,15 +208,17 @@ God.executeApp = function executeApp(env, cb) {
     if (env_copy['watch']) {
       God.watch.enable(env_copy);
     }
+
+    if (!env_copy['autostart']) {
+      var clu = {pm2_env: env_copy, process: {pid: 0}};
+      God.clusters_db[env_copy.pm_id] = clu;
+      return cb(null, clu);
+    }
   }
 
   God.registerCron(env_copy)
 
-  if(!env_copy['autostart']) {
-    var clu = {pm2_env: env_copy, process: {pid: 0}};
-    God.clusters_db[env_copy.pm_id] = clu;
-    return cb(null, clu);
-  }
+  
 
   /** Callback when application is launched */
   var readyCb = function ready(proc) {

--- a/lib/God.js
+++ b/lib/God.js
@@ -217,7 +217,6 @@ God.executeApp = function executeApp(env, cb) {
   }
 
   God.registerCron(env_copy)
-
   
 
   /** Callback when application is launched */

--- a/lib/God.js
+++ b/lib/God.js
@@ -217,7 +217,6 @@ God.executeApp = function executeApp(env, cb) {
   }
 
   God.registerCron(env_copy)
-  
 
   /** Callback when application is launched */
   var readyCb = function ready(proc) {


### PR DESCRIPTION
When autostart is false, the process won't start when running 'pm2 start \<id\>'.  The check should only be performed when the process is not already in the list.

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->