### PR TITLE
Add support for disabling version checks

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -168,7 +168,7 @@ Client.prototype.initFileStructure = function (opts) {
     }
   }
 
-  if (!process.env.PM2_PROGRAMMATIC && !fs.existsSync(path.join(opts.PM2_HOME, 'touch'))) {
+  if (!process.env.PM2_DISABLE_VERSION_CHECK && !process.env.PM2_PROGRAMMATIC && !fs.existsSync(path.join(opts.PM2_HOME, 'touch'))) {
 
     var vCheck = require('./VersionCheck.js')
 

--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -198,12 +198,14 @@ module.exports = function(God) {
   God.Worker.start = function() {
     timer = setInterval(wrappedTasks, cst.WORKER_INTERVAL);
 
-    setInterval(() => {
-      vCheck({
-        state: 'check',
-        version: pkg.version
-      })
-    }, 1000 * 60 * 60 * 24)
+    if (!process.env.PM2_DISABLE_VERSION_CHECK) {
+      setInterval(() => {
+        vCheck({
+          state: 'check',
+          version: pkg.version,
+        });
+      }, 1000 * 60 * 60 * 24);
+    }
   };
 
   God.Worker.stop = function() {


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4695
| License       | MIT
| Doc PR        | 
<!--
*Please update this template with something that matches your PR*
-->

This adds support for a `PM2_DISABLE_VERSION_CHECKS` env variable, which will disabling running version checks for PM2.
