### PR TITLE
Fixes 5895 - treekill syntax incompatible with freebsd

### DIFF
--- a/lib/TreeKill.js
+++ b/lib/TreeKill.js
@@ -16,6 +16,7 @@ module.exports = function (pid, signal, callback) {
   case 'win32':
     exec('taskkill /pid ' + pid + ' /T /F', { windowsHide: true }, callback);
     break;
+  case 'freebsd':
   case 'darwin':
     buildProcessTree(pid, tree, pidsToProcess, function (parentPid) {
       return spawn('pgrep', ['-P', parentPid]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5895 
| License       | MIT
| Doc PR        | 