### PR TITLE
fix: Enable PM2 module update from tarball

### DIFF
--- a/lib/API/Modules/Modularizer.js
+++ b/lib/API/Modules/Modularizer.js
@@ -87,7 +87,7 @@ Modularizer.package = function(CLI, module_path, cb) {
   var fullpath = process.cwd()
   if (module_path)
     fullpath = require('path').resolve(module_path)
-  TAR.package(fullpath, process.cwd(), cb)
+  TAR.packager(fullpath, process.cwd(), cb)
 }
 
 /**

--- a/lib/API/Modules/TAR.js
+++ b/lib/API/Modules/TAR.js
@@ -283,8 +283,8 @@ function packager(module_path, target_path, cb) {
 
   var tar = exec(cmd, (err, sto, ste) => {
     if (err) {
-      console.log(sto.toString().trim())
-      console.log(ste.toString().trim())
+      console.error(sto.toString().trim())
+      console.error(ste.toString().trim())
     }
   })
 

--- a/lib/binaries/CLI.js
+++ b/lib/binaries/CLI.js
@@ -504,9 +504,11 @@ commander.command('install <module|git:// url>')
   });
 
 commander.command('module:update <module|git:// url>')
+  .option('--tarball', 'is local tarball')
   .description('update a module and run it forever')
-  .action(function(plugin_name) {
-    pm2.install(plugin_name);
+  .action(function(plugin_name, opts) {
+    require('util')._extend(commander, opts);
+    pm2.install(plugin_name, commander);
   });
 
 


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5680
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

1) enbale module:update tarball
2) update TAR.package to TAR.packager