### PR TITLE
fix allowing to update namespaced pm2 NPM module (@org/module-name)

### DIFF
--- a/lib/tools/copydirSync.js
+++ b/lib/tools/copydirSync.js
@@ -35,7 +35,7 @@ function copydirSync(from, to, options) {
         fs.statSync(to);
       } catch(err) {
         if(err.code === 'ENOENT') {
-          fs.mkdirSync(to);
+          fs.mkdirSync(to, { recursive: true });
           options.debug && console.log('>> ' + to);
         } else {
           throw err;


### PR DESCRIPTION
This PR fixes the issue when trying to run `pm2 install @colyseus/tools` the second time:

Error:

```
Error: ENOENT: no such file or directory, mkdir '/tmp/@colyseus/tools'
    at Object.mkdirSync (node:fs:1371:26)
    at copydirSync (/usr/lib/node_modules/pm2/lib/tools/copydirSync.js:38:14)
    at Object.backup (/usr/lib/node_modules/pm2/lib/API/Modules/NPM.js:438:5)
    at /usr/lib/node_modules/pm2/lib/API/Modules/NPM.js:170:16
    at moduleExistInLocalDB (/usr/lib/node_modules/pm2/lib/API/Modules/NPM.js:162:10)
    at Object.install (/usr/lib/node_modules/pm2/lib/API/Modules/NPM.js:166:3)
    at Modularizer.install (/usr/lib/node_modules/pm2/lib/API/Modules/Modularizer.js:48:9)
    at CLI.install (/usr/lib/node_modules/pm2/lib/API/Modules/index.js:27:17)
    at Command.<anonymous> (/usr/lib/node_modules/pm2/lib/binaries/CLI.js:503:9)
    at Command.listener (/usr/lib/node_modules/pm2/node_modules/commander/index.js:315:8) {
```

The `recursive` option for `mkdirSync` is available since Node.js 10.12.0. So this change should be safe for everybody.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

