### PR TITLE
Allow ENV to overwrite PORTS on Windows

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -70,6 +70,14 @@ module.exports = function(PM2_HOME) {
     BUILTIN_NPM_PATH         : has_node_embedded === true ? p.resolve(__dirname, './node/bin/npm') : null,
   };
 
+  if (process.platform === 'win32' ||
+      process.platform === 'win64') {
+    //@todo instead of static unique rpc/pub file custom with PM2_HOME or UID
+    pm2_file_stucture.DAEMON_RPC_PORT = '\\\\.\\pipe\\rpc.sock';
+    pm2_file_stucture.DAEMON_PUB_PORT = '\\\\.\\pipe\\pub.sock';
+    pm2_file_stucture.INTERACTOR_RPC_PORT = '\\\\.\\pipe\\interactor.sock';
+  };
+
   // allow overide of file paths via environnement
   var paths = Object.keys(pm2_file_stucture);
   paths.forEach(function (key) {
@@ -78,14 +86,6 @@ module.exports = function(PM2_HOME) {
       pm2_file_stucture[key] = process.env[envKey];
     }
   });
-
-  if (process.platform === 'win32' ||
-      process.platform === 'win64') {
-    //@todo instead of static unique rpc/pub file custom with PM2_HOME or UID
-    pm2_file_stucture.DAEMON_RPC_PORT = '\\\\.\\pipe\\rpc.sock';
-    pm2_file_stucture.DAEMON_PUB_PORT = '\\\\.\\pipe\\pub.sock';
-    pm2_file_stucture.INTERACTOR_RPC_PORT = '\\\\.\\pipe\\interactor.sock';
-  }
 
   return pm2_file_stucture;
 };


### PR DESCRIPTION
Currently for Windows the ports are overridden with static values after allowing ENV to overwrite those same settings. Users should be allowed to specify these via ENV on Windows the same as other platforms. In particular, by setting those PM2 can effectively run under less privileged users when being run as a service (via pm2-installer).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5930
| License       | MIT
| Doc PR        | N/A