### PR TITLE
Adding KILL_RETRY_TIME environment variable

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -103,6 +103,7 @@ var csts = {
 
   WORKER_INTERVAL         : process.env.PM2_WORKER_INTERVAL || 30000,
   KILL_TIMEOUT            : process.env.PM2_KILL_TIMEOUT || 1600,
+  KILL_RETRY_TIME         : process.env.PM2_KILL_RETRY_TIME || 100,
   KILL_SIGNAL             : process.env.PM2_KILL_SIGNAL || 'SIGINT',
   KILL_USE_MESSAGE        : process.env.PM2_KILL_USE_MESSAGE || false,
 

--- a/lib/API/schema.json
+++ b/lib/API/schema.json
@@ -363,7 +363,7 @@
   },
   "kill_retry_time": {
     "type": "number",
-    "default" : 100
+    "docDefault" : 100
   },
   "write": {
     "type": "boolean"

--- a/lib/God/Methods.js
+++ b/lib/God/Methods.js
@@ -156,6 +156,7 @@ module.exports = function(God) {
 
     var timeout      = null;
     var kill_timeout = (pm2_env && pm2_env.kill_timeout) ? pm2_env.kill_timeout : cst.KILL_TIMEOUT;
+    var kill_retry_time = (pm2_env && pm2_env.kill_retry_time) ? pm2_env.kill_retry_time : cst.KILL_RETRY_TIME;
     var mode         = pm2_env.exec_mode;
 
     var timer = setInterval(function() {
@@ -165,9 +166,9 @@ module.exports = function(God) {
         clearInterval(timer);
         return cb(null, true);
       }
-      console.log('pid=%d msg=failed to kill - retrying in %dms', pid, pm2_env.kill_retry_time);
+      console.log('pid=%d msg=failed to kill - retrying in %dms', pid, kill_retry_time);
       return false;
-    }, pm2_env.kill_retry_time);
+    }, kill_retry_time);
 
     timeout = setTimeout(function() {
       clearInterval(timer);


### PR DESCRIPTION
There is no way, when using `pm2-runtime`, to change the `kill_retry_timeout`, as the option is largely ignored by the CLI.

Adding the possibilit to at least use  the env-var KILL_RETRY_TIME
