### PR TITLE
Remove deprecated util._extend and util.isArray with Object.assign and Array.isArray

### DIFF
--- a/examples/sourcemap-auto-resolve/API.js
+++ b/examples/sourcemap-auto-resolve/API.js
@@ -63,7 +63,7 @@ var API = module.exports = function(opts) {
   if (opts.pm2_home) {
     // Override default conf file
     this.pm2_home        = opts.pm2_home;
-    conf = util._extend(conf, path_structure(this.pm2_home));
+    conf = Object.assign(conf, path_structure(this.pm2_home));
   }
   else if (opts.independent == true && conf.IS_WINDOWS === false) {
     // Create an unique pm2 instance
@@ -75,7 +75,7 @@ var API = module.exports = function(opts) {
     // It will go as in proc
     if (typeof(opts.daemon_mode) == 'undefined')
       this.daemon_mode = false;
-    conf = util._extend(conf, path_structure(this.pm2_home));
+    conf = Object.assign(conf, path_structure(this.pm2_home));
   }
 
   this._conf = conf;
@@ -299,7 +299,7 @@ API.prototype.start = function(cmd, opts, cb) {
 
   var that = this;
 
-  if (util.isArray(opts.watch) && opts.watch.length === 0)
+  if (Array.isArray(opts.watch) && opts.watch.length === 0)
     opts.watch = (opts.rawArgs ? !!~opts.rawArgs.indexOf('--watch') : !!~process.argv.indexOf('--watch')) || false;
 
   if (Common.isConfigFile(cmd) || (typeof(cmd) === 'object'))
@@ -760,7 +760,7 @@ API.prototype._startScript = function(script, opts, cb) {
       resolved_paths.env['PM2_HOME'] = that.pm2_home;
 
       var additional_env = Modularizer.getAdditionalConf(resolved_paths.name);
-      util._extend(resolved_paths.env, additional_env);
+      Object.assign(resolved_paths.env, additional_env);
 
       // Is KM linked?
       resolved_paths.km_link = that.gl_is_km_linked;
@@ -940,7 +940,7 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
       // Notice: if people use the same name in different apps,
       //         duplicated envs will be overrode by the last one
       var env = envs.reduce(function(e1, e2){
-        return util._extend(e1, e2);
+        return Object.assign(e1, e2);
       });
 
       // When we are processing JSON, allow to keep the new env by default
@@ -1012,7 +1012,7 @@ API.prototype._startJson = function(file, opts, action, pipe, cb) {
       resolved_paths.env['PM2_HOME'] = that.pm2_home;
 
       var additional_env = Modularizer.getAdditionalConf(resolved_paths.name);
-      util._extend(resolved_paths.env, additional_env);
+      Object.assign(resolved_paths.env, additional_env);
 
       resolved_paths.env = Common.mergeEnvironmentVariables(resolved_paths, opts.env, deployConf);
 
@@ -1226,7 +1226,7 @@ API.prototype._operate = function(action_name, process_name, envs, cb) {
           if (conf.PM2_PROGRAMMATIC == true)
             new_env = Common.safeExtend({}, process.env);
           else
-            new_env = util._extend({}, process.env);
+            new_env = Object.assign({}, process.env);
 
           Object.keys(envs).forEach(function(k) {
             new_env[k] = envs[k];
@@ -1355,7 +1355,7 @@ API.prototype._operate = function(action_name, process_name, envs, cb) {
        * if yes load configuration variables and merge with the current environment
        */
       var additional_env = Modularizer.getAdditionalConf(process_name);
-      util._extend(envs, additional_env);
+      Object.assign(envs, additional_env);
 
       return processIds(ids, cb);
     });
@@ -1401,7 +1401,7 @@ API.prototype._handleAttributeUpdate = function(opts) {
 
   delete appConf.exec_mode;
 
-  if (util.isArray(appConf.watch) && appConf.watch.length === 0) {
+  if (Array.isArray(appConf.watch) && appConf.watch.length === 0) {
     if (!~opts.rawArgs.indexOf('--watch'))
       delete appConf.watch
   }

--- a/lib/binaries/CLI.js
+++ b/lib/binaries/CLI.js
@@ -504,7 +504,7 @@ commander.command('install <module|git:// url>')
   .option('--safe [time]', 'keep module backup, if new module fail = restore with previous')
   .description('install or update a module and run it forever')
   .action(function(plugin_name, opts) {
-    require('util')._extend(commander, opts);
+    Object.assign(commander, opts);
     pm2.install(plugin_name, commander);
   });
 
@@ -512,7 +512,7 @@ commander.command('module:update <module|git:// url>')
   .option('--tarball', 'is local tarball')
   .description('update a module and run it forever')
   .action(function(plugin_name, opts) {
-    require('util')._extend(commander, opts);
+    Object.assign(commander, opts);
     pm2.install(plugin_name, commander);
   });
 

--- a/test/programmatic/watcher.js
+++ b/test/programmatic/watcher.js
@@ -3,7 +3,6 @@ var p = require('path');
 var fs = require('fs')
 var EventEmitter = require('events').EventEmitter
 var PM2  = require('../..');
-var extend = require('util')._extend
 
 var cwd = __dirname + '/../fixtures/watcher';
 
@@ -91,7 +90,7 @@ describe('Watcher', function() {
   it('should be watching', function(cb) {
     testPM2Env('server-watch:online')({watch: true}, cb)
 
-    var json_app = extend(json, {watch: true});
+    var json_app = Object.assign(json, {watch: true});
     pm2.start(json_app, errShouldBeNull)
   })
 
@@ -114,19 +113,19 @@ describe('Watcher', function() {
     pm2.stop('server-watch', errShouldBeNull)
 
     // this would be better:
-    // pm2.actionFromJson('stopProcessId', extend(json, {watch: false}), errShouldBeNull)
+    // pm2.actionFromJson('stopProcessId', Object.assign(json, {watch: false}), errShouldBeNull)
     // or :
     // pm2.stop('server-watch', {watch: false}, errShouldBeNull)
   })
 
   it('should not watch', function(cb) {
     testPM2Env('server-watch:online')({watch: false}, cb)
-    pm2.restart(extend(json, {watch: false}), errShouldBeNull)
+    pm2.restart(Object.assign(json, {watch: false}), errShouldBeNull)
   })
 
   it('should watch', function(cb) {
     testPM2Env('server-watch:online')({restart_time: 3, watch: true}, cb)
-    pm2.restart(extend(json, {watch: true}), errShouldBeNull)
+    pm2.restart(Object.assign(json, {watch: true}), errShouldBeNull)
   })
 
   it('should delete process', function(cb) {
@@ -179,12 +178,12 @@ describe('Watcher', function() {
 
   it('should work with watch_delay', function(cb) {
     testPM2Env('server-watch:online')({watch: true, watch_delay: 4000}, cb);
-    pm2.start(extend(json, {watch: true, watch_delay: 4000}), errShouldBeNull);
+    pm2.start(Object.assign(json, {watch: true, watch_delay: 4000}), errShouldBeNull);
   })
 
   it('should not crash with watch_delay without watch', function(cb) {
     testPM2Env('server-watch:online')({watch_delay: 4000}, cb);
-    pm2.start(extend(json, {watch_delay: 4000}), errShouldBeNull);
+    pm2.start(Object.assign(json, {watch_delay: 4000}), errShouldBeNull);
   })
 
   /**


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->