### PR TITLE
fix: cannot find module ansis on Node.js < 14

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2,13 +2,13 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "pm2-beta",
+      "name": "pm2",
       "dependencies": {
         "@pm2/agent": "~2.1.1",
         "@pm2/io": "~6.1.0",
         "@pm2/js-api": "~0.8.0",
         "@pm2/pm2-version-check": "latest",
-        "ansis": "4.0.0",
+        "ansis": "4.0.0-node10",
         "async": "~3.2.6",
         "blessed": "0.1.81",
         "chokidar": "^3.5.3",
@@ -66,7 +66,7 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, ""],
 
-    "ansis": ["ansis@4.0.0", "", {}, "sha512-P8nrHI1EyW9OfBt1X7hMSwGN2vwRuqHSKJAT1gbLWZRzDa24oHjYwGHvEgHeBepupzk878yS/HBZ0NMPYtbolw=="],
+    "ansis": ["ansis@4.0.0-node10", "", {}, "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, ""],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
-  "name": "pm2-beta",
-  "version": "6.0.4",
+  "name": "pm2",
+  "version": "6.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pm2-beta",
-      "version": "6.0.4",
+      "name": "pm2",
+      "version": "6.0.5",
       "license": "AGPL-3.0",
       "dependencies": {
         "@pm2/agent": "~2.1.1",
         "@pm2/io": "~6.1.0",
         "@pm2/js-api": "~0.8.0",
         "@pm2/pm2-version-check": "latest",
+        "ansis": "4.0.0-node10",
         "async": "~3.2.6",
         "blessed": "0.1.81",
-        "chalk": "3.0.0",
         "chokidar": "^3.5.3",
         "cli-tableau": "^2.0.0",
         "commander": "2.15.1",
@@ -278,6 +278,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.0.0-node10",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.0.0-node10.tgz",
+      "integrity": "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/anymatch": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "@pm2/js-api": "~0.8.0",
     "@pm2/io": "~6.1.0",
     "@pm2/pm2-version-check": "latest",
-    "ansis": "4.0.0",
+    "ansis": "4.0.0-node10",
     "async": "~3.2.6",
     "blessed": "0.1.81",
     "chokidar": "^3.5.3",


### PR DESCRIPTION
<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5984
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
<!--
*Please update this template with something that matches your PR*
-->

Hello @Unitech,

This PR fixes the incompatibility with Node.js <= 12 introduced with the PR #5983. I'll leave this as a draft for now.

Although PM2 v6 officially [requires at least Node.js 16](https://github.com/Unitech/pm2/blob/e71120a5172e87f509563f2542942458b115783a/package.json#L6), many users continue to run pm2 v6 on unsupported Node.js versions 10–12.

Many other dependencies require Node.js 14+:
- proxy-agent@6.4.0
- agent-base@7.1.3
- http-proxy-agent@7.0.2
- https-proxy-agent@7.0.6
- socks-proxy-agent@8.0.5
- pac-proxy-agent@7.2.0
- get-uri@6.0.4
- data-uri-to-buffer@6.0.2
- degenerator@5.0.1

By the way, the README should be updated to say:

> All Node.js versions are supported starting Node.js 14.x.


## How to reproduce the issue

The pm2 `6.0.6` uses package ansis `4.0.0` (node >= 14).
Check package.json:
```json
"dependencies": {
  ..
 "ansis": "4.0.0",
  ..
}
```

Run from pm2 project directory:
```
docker run --rm -it -v "$PWD":/app -w /app --entrypoint bash node:10 -c './bin/pm2 ls'
```

Output:
```
internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module 'ansis'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/app/constants.js:10:14)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```

## How to fix this incompatibility issue

Replace ansis `4.0.0` with special version `4.0.0-node10` compatible with Node.js 10+:
```diff
"dependencies": {
 ..
- "ansis": "4.0.0",
+ "ansis": "4.0.0-node10",
 ..
}
```

## Test pm2 with `4.0.0-node10` in Node.js 10

Run from pm2 project directory:
```
docker run --rm -it -v "$PWD":/app -w /app --entrypoint bash node:10 -c './bin/pm2 ls'
```

Output:
![image](https://github.com/user-attachments/assets/a0e4496e-8441-4a9a-bf7e-4ff967416d9f)
