### PR TITLE
fix: setting `source_map_support: false` disables source maps

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -165,7 +165,7 @@ Common.prepareAppConf = function(opts, app) {
   /**
    * Auto detect .map file and enable source map support automatically
    */
-  if (app.disable_source_map_support != true) {
+  if (app.disable_source_map_support != true && app.source_map_support != false) {
     try {
       fs.accessSync(app.pm_exec_path + '.map', fs.R_OK);
       app.source_map_support = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

Hey @Unitech 

- In the ecosystem (JSON) file
  - if you set `disable_source_map_support: true`, this will correctly disable source maps
  - but if you set `source_map_support: false`, this has no effect - source maps will still be detected.
- This PR ensures that setting `source_map_support: false` correctly disables source maps, so that it has the same behavior as setting `disable_source_map_support: true`
- This is related to (but does not fix) #5003. I had similar issues getting Sentry to work correctly because pm2 was detecting source map files even though I had already set `source_map_support: false`. This fix prevents that issue from happening again with other people using pm2 with ecosystem files.