### PR TITLE
fix: command "pm2 reloadLogs" does not respect silent flags when used in daemon mode (like when executing with Node.js child_process.exec)

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -122,6 +122,23 @@ module.exports = function(CLI) {
   };
 
   /**
+   * Same as reloadLogs but without console outputs.
+   * @method reloadLogsSilently
+   * @return
+   */
+  CLI.prototype.reloadLogsSilently = function(cb) {
+    var that = this;
+
+    that.Client.executeRemote('reloadLogsSilently', {}, function(err, logs) {
+      if (err) {
+        Common.printError(err);
+        return cb ? cb(Common.retErr(err)) : that.exitCli(cst.ERROR_EXIT);
+      }
+      return cb ? cb(null, logs) : that.exitCli(cst.SUCCESS_EXIT);
+    });
+  };
+
+  /**
    * Description
    * @method streamLogs
    * @param {String} id

--- a/lib/Daemon.js
+++ b/lib/Daemon.js
@@ -247,7 +247,8 @@ Daemon.prototype.innerStart = function(cb) {
     ping                    : God.ping,
     getVersion              : God.getVersion,
     getReport               : God.getReport,
-    reloadLogs              : God.reloadLogs
+    reloadLogs              : God.reloadLogs,
+    reloadLogsSilently      : God.reloadLogsSilently,
   });
 
   this.startLogic();

--- a/lib/God/ActionMethods.js
+++ b/lib/God/ActionMethods.js
@@ -607,24 +607,26 @@ module.exports = function(God) {
    * Description
    * @method reloadLogs
    * @param {} opts
-   * @param {} cb
+   * @param {Boolean} opts.silent If true, the command won't ouput messages to the console.
+   * @param {Function} cb
    * @return CallExpression
    */
   God.reloadLogs = function(opts, cb) {
-    console.log('Reloading logs...');
+    const { silent } = opts || {}
+    if (!silent) console.log('Reloading logs...');
     var processIds = Object.keys(God.clusters_db);
 
     processIds.forEach(function (id) {
       var cluster = God.clusters_db[id];
 
-      console.log('Reloading logs for process id %d', id);
+      if (!silent) console.log('Reloading logs for process id %d', id);
 
       if (cluster && cluster.pm2_env) {
         // Cluster mode
         if (cluster.send && cluster.pm2_env.exec_mode == 'cluster_mode') {
           try {
             cluster.send({
-              type:'log:reload'
+              type: silent ? 'log:reloadSilently' : 'log:reload'
             });
           } catch(e) {
             console.error(e.message || e);
@@ -640,6 +642,17 @@ module.exports = function(God) {
     });
 
     return cb(null, {});
+  };
+
+  /**
+   * Same as reloadLogs but without console outputs.
+   * @method reloadLogsSilently
+   * @param {} opts
+   * @param {Function} cb
+   * @return CallExpression
+   */
+  God.reloadLogsSilently = function(opts, cb) {
+    return God.reloadLogs({ silent: true }, cb)
   };
 
   /**

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -120,7 +120,7 @@ function exec(script, stds) {
   }
 
   process.on('message', function (msg) {
-    if (msg.type === 'log:reload') {
+    if (['log:reload', 'log:reloadSilently'].includes(msg.type)) {
       for (var k in stds){
         if (typeof stds[k] == 'object' && !isNaN(stds[k].fd)){
           if (stds[k].destroy) stds[k].destroy();
@@ -132,7 +132,7 @@ function exec(script, stds) {
       Utility.startLogging(stds, function (err) {
         if (err)
           return console.error('Failed to reload logs:', err.stack);
-        console.log('Reloading log...');
+        if (msg.type !== 'log:reloadSilently') console.log('Reloading log...');
       });
     }
   });

--- a/lib/binaries/CLI.js
+++ b/lib/binaries/CLI.js
@@ -880,6 +880,16 @@ commander.command('reloadLogs')
   });
 
 //
+// Reload all logs but silently.
+// When using the CLI, this is equivalent to pm2 reloadLogs -s (or --silent).
+//
+commander.command('reloadLogsSilently')
+  .description('reload all logs silently')
+  .action(function() {
+    pm2.reloadLogsSilently();
+  });
+
+//
 // Log streaming
 //
 commander.command('logs [id|name|namespace]')
@@ -1022,7 +1032,7 @@ commander.command('examples')
 // Catch all
 //
 commander.command('*')
-  .action(function() {
+  .action(function(cmd) {
     console.log(cst.PREFIX_MSG_ERR + chalk.bold('Command not found\n'));
     displayUsage();
     // Check if it does not forget to close fds from RPC


### PR DESCRIPTION
When programmatically executing "pm2 reloadLogs" like with child_process.exec, the flags -s and --silent are not respected because the command is passed through pm2-axon-rpc. The only way I found to obtain the desired behavior is to introduce a dedicated command "pm2 reloadLogsSilently" that does the job.

This is useful to avoid the pollution of the console messages when rotating the logs.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5927
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls