### PR TITLE
fix: update console log commands to use double quotes for PATH variable

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -29,11 +29,11 @@ module.exports = function(CLI) {
     }
 
     if (opts.user) {
-      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' pm2 ' + opts.args[1].name() + ' ' + platform + ' -u ' + opts.user + ' --hp ' + process.env.HOME);
+      console.log('sudo env PATH="$PATH:' + path.dirname(process.execPath) + '" pm2 ' + opts.args[1].name() + ' ' + platform + ' -u ' + opts.user + ' --hp ' + process.env.HOME);
       return cb(new Error('You have to run this with elevated rights'));
     }
     return sexec('whoami', {silent: true}, function(err, stdout, stderr) {
-      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' ' + pm2_bin_path + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + stdout.trim() + ' --hp ' + process.env.HOME);
+      console.log('sudo env PATH="$PATH:' + path.dirname(process.execPath) + '" ' + pm2_bin_path + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + stdout.trim() + ' --hp ' + process.env.HOME);
       return cb(new Error('You have to run this with elevated rights'));
     });
   }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [#6010](https://github.com/Unitech/pm2/issues/6010)
| License       | MIT
| Doc PR        | Here


This PR updates console log commands to use double quotes for PATH variable.
