### PR TITLE
Unit fix

### DIFF
--- a/lib/API/UX/helpers.js
+++ b/lib/API/UX/helpers.js
@@ -15,15 +15,15 @@ Helpers.bytesToSize = function(bytes, precision) {
   var terabyte = gigabyte * 1024
 
   if ((bytes >= 0) && (bytes < kilobyte)) {
-    return bytes + 'b '
+    return bytes + 'B '
   } else if ((bytes >= kilobyte) && (bytes < megabyte)) {
-    return (bytes / kilobyte).toFixed(precision) + 'kb '
+    return (bytes / kilobyte).toFixed(precision) + 'KiB '
   } else if ((bytes >= megabyte) && (bytes < gigabyte)) {
-    return (bytes / megabyte).toFixed(precision) + 'mb '
+    return (bytes / megabyte).toFixed(precision) + 'MiB '
   } else if ((bytes >= gigabyte) && (bytes < terabyte)) {
-    return (bytes / gigabyte).toFixed(precision) + 'gb '
+    return (bytes / gigabyte).toFixed(precision) + 'GiB '
   } else if (bytes >= terabyte) {
-    return (bytes / terabyte).toFixed(precision) + 'tb '
+    return (bytes / terabyte).toFixed(precision) + 'TiB '
   } else {
     return bytes + 'b '
   }

--- a/lib/API/UX/pm2-ls.js
+++ b/lib/API/UX/pm2-ls.js
@@ -338,7 +338,7 @@ function containersListing(sys_infos) {
     var state = UxHelpers.colorStatus(c.state)
 
     if (stacked_docker)
-      docker_table.push([id, c.image, state, `${cpu}%`, `${mem}mb`])
+      docker_table.push([id, c.image, state, `${cpu}%`, `${mem} MiB`])
     else {
       docker_table.push([
         id,
@@ -346,7 +346,7 @@ function containersListing(sys_infos) {
         state,
         c.restartCount,
         `${cpu == 0 ? '0' : cpu}%`,
-        `${mem}mb`,
+        `${mem} MiB`,
         `${c.stats.netIO.rx}/${isNaN(c.stats.netIO.tx) == true ? '0.0' : c.stats.netIO.tx}`,
         `${c.stats.blockIO.r}/${c.stats.blockIO.w}`
       ])


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixes | https://github.com/Unitech/pm2/issues/6018
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls
```

This fixes the problem that units are written like "mb", "gb" and so on. This should be "MiB", "GiB", etc.