### PR TITLE
fix: prettylist should output valid json

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -1667,7 +1667,7 @@ class API {
       }
 
       if (debug) {
-        process.stdout.write(util.inspect(list, false, null, false));
+        process.stdout.write(JSON.stringify(list, null, 2));
       }
       else {
         process.stdout.write(JSON.stringify(list));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

what node:inspect produces is definitely not json

<img width="540" height="262" alt="image" src="https://github.com/user-attachments/assets/9e3442c5-ed6a-43a7-a7cf-de6b7546b522" />

