### PR TITLE
Fixed version of @pm2/pm2-version-check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "pm2",
-  "version": "6.0.11",
+  "version": "6.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm2",
-      "version": "6.0.11",
+      "version": "6.0.13",
       "license": "AGPL-3.0",
       "dependencies": {
         "@pm2/agent": "~2.1.1",
         "@pm2/blessed": "0.1.81",
         "@pm2/io": "~6.1.0",
         "@pm2/js-api": "~0.8.0",
-        "@pm2/pm2-version-check": "latest",
+        "@pm2/pm2-version-check": "^1.0.4",
         "ansis": "4.0.0-node10",
         "async": "3.2.6",
         "chokidar": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@pm2/agent": "~2.1.1",
     "@pm2/js-api": "~0.8.0",
     "@pm2/io": "~6.1.0",
-    "@pm2/pm2-version-check": "latest",
+    "@pm2/pm2-version-check": "^1.0.4",
     "ansis": "4.0.0-node10",
     "async": "3.2.6",
     "@pm2/blessed": "0.1.81",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Updated the `@pm2/pm2-version-check` version in `package.json` to `^1.0.4` instead of `latest`. 

`latest` is breaking the `package-lock.json` generation in NX monorepos, and it's generally not a good practice.