### PR TITLE
fix: support windows cmd shims in fork mode

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -861,6 +861,25 @@ class API {
           Common.err(e.message);
           return cb(Common.retErr(e));
         }
+        
+        // Windows shim auto-detection for CLI wrappers (.cmd/.bat)
+        if (
+          conf.IS_WINDOWS &&
+          resolved_paths &&
+          typeof resolved_paths.pm_exec_path === 'string' &&
+          /\.(cmd|bat)$/i.test(resolved_paths.pm_exec_path)
+        ) {
+          const interp = resolved_paths.exec_interpreter;
+
+          if (
+            !interp ||
+            interp === 'node' ||
+            interp === process.execPath ||
+            /node(.exe)?$/i.test(String(interp))
+          ) {
+            resolved_paths.exec_interpreter = 'none';
+          }
+        }
 
         Common.printOut(conf.PREFIX_MSG + 'Starting %s in %s (%d instance' + (resolved_paths.instances > 1 ? 's' : '') + ')',
           resolved_paths.pm_exec_path, resolved_paths.exec_mode, resolved_paths.instances);

--- a/lib/God/ForkMode.js
+++ b/lib/God/ForkMode.js
@@ -43,7 +43,28 @@ module.exports = function ForkMode(God) {
     var interpreter = pm2_env.exec_interpreter || process.execPath;
     var pidFile     = pm2_env.pm_pid_path;
 
-    if (interpreter !== 'none') {
+    var isWindows   = process.platform === 'win32';
+    var execPath    = pm2_env.pm_exec_path || '';
+    var isCmdLike   = isWindows && typeof execPath === 'string' && /\.(cmd|bat)$/i.test(execPath);
+    var isNoInterp  = interpreter === 'none';
+
+    if (isCmdLike) {
+      const quote = (s) =>
+        /[\s"&'`]/.test(s)
+          ? `"${String(s).replace(/"/g, '\\"')}"`
+          : String(s);
+
+      const base = quote(execPath);
+      let extra  = '';
+
+      if (pm2_env.args && Array.isArray(pm2_env.args) && pm2_env.args.length > 0) {
+        extra = ' ' + pm2_env.args.map(a => quote(a)).join(' ');
+      }
+
+      command = base + extra;
+      args = [];
+    }
+    else if (!isNoInterp) {
       command = interpreter;
 
       if (pm2_env.node_args && Array.isArray(pm2_env.node_args)) {
@@ -61,16 +82,21 @@ module.exports = function ForkMode(God) {
       else if (interpreter.includes('bun') === true) {
         args.push(path.resolve(path.dirname(module.filename), '..', 'ProcessContainerForkBun.js'));
       }
-      else
-        args.push(pm2_env.pm_exec_path);
+      else {
+        args.push(execPath);
+      }
+
+      if (pm2_env.args) {
+        args = args.concat(pm2_env.args);
+      }
     }
     else {
-      command = pm2_env.pm_exec_path;
+      command = execPath;
       args = [ ];
-    }
 
-    if (pm2_env.args) {
-      args = args.concat(pm2_env.args);
+      if (pm2_env.args) {
+        args = args.concat(pm2_env.args);
+      }
     }
 
     // piping stream o file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5991, #5871
| License       | MIT
| Doc PR        | https://github.com/pm2-hive/pm2-hive.github.io/pulls

Add detection for .cmd / .bat targets on Windows in forkMode.

When pm_exec_path is a Windows shim (e.g. npm.cmd), run it via shell with no Node interpreter, instead of trying to load it as JavaScript.

On Windows, commands like script: "npm" or exec_interpreter: "none" combined with pm_exec_path pointing to npm.cmd caused PM2 to spawn node npm.cmd, leading Node to parse the .cmd file as JS and crash with a syntax error.