### PR TITLE
update pidusage to 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "js-yaml": "4.1.0",
         "mkdirp": "1.0.4",
         "needle": "2.4.0",
-        "pidusage": "3.0.2",
+        "pidusage": "4.0.1",
         "pm2-axon": "~4.0.1",
         "pm2-axon-rpc": "~0.7.1",
         "pm2-deploy": "~1.0.2",
@@ -3062,14 +3062,15 @@
       }
     },
     "node_modules/pidusage": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-3.0.2.tgz",
-      "integrity": "sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-4.0.1.tgz",
+      "integrity": "sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/pm2-axon": {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "fclone": "1.0.11",
     "mkdirp": "1.0.4",
     "needle": "2.4.0",
-    "pidusage": "3.0.2",
+    "pidusage": "4.0.1",
     "pm2-axon": "~4.0.1",
     "pm2-axon-rpc": "~0.7.1",
     "pm2-deploy": "~1.0.2",


### PR DESCRIPTION
This PR updates the pidusage npm dependency to version 4.0.1, which resolves the usage of the deprecated WMIC api on windows (related pidusage PR here: https://github.com/soyuka/pidusage/pull/143)

<!--
Please always submit pull requests on the development branch.
-->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5940, #5311
| License       | MIT
<!--
*Please update this template with something that matches your PR*
-->