### PR TITLE
CVE-2025-64718 Update js-yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "enquirer": "2.3.6",
         "eventemitter2": "5.0.1",
         "fclone": "1.0.11",
-        "js-yaml": "4.1.0",
+        "js-yaml": "4.1.1",
         "mkdirp": "1.0.4",
         "needle": "2.4.0",
         "pidusage": "3.0.2",
@@ -1117,9 +1117,10 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "source-map-support": "0.5.21",
     "sprintf-js": "1.1.2",
     "vizion": "~2.2.1",
-    "js-yaml": "4.1.0"
+    "js-yaml": "4.1.1"
   },
   "overrides": {
     "debug": "4.4.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This addresses [CVE-2025-64718](https://www.mend.io/vulnerability-database/CVE-2025-64718) that is in js-yaml version 4.1.0 and fixed in 4.1.1. It is a moderate vulnerability with a score of 5.3.

[js-yaml commit](https://github.com/nodeca/js-yaml/commit/383665ff4248ec2192d1274e934462bb30426879) fixing the issue if interested.

Tests passed on my local machine. 