### PR TITLE
fix(types): add missing port property to StartOptions interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -555,6 +555,10 @@ export interface StartOptions {
   source_map_support?: any;
   disable_source_map_support?: any;
   /**
+   * Shortcut to inject a PORT environment variable.
+   */
+  port?: number;
+  /**
    * The environment variables to pass on to the process.
    */
   env?: { [key: string]: string; };


### PR DESCRIPTION
## Description

The `port` configuration property is defined in `lib/API/schema.json` but was missing from the TypeScript type definitions in `types/index.d.ts`.

This PR adds the `port` property to the `StartOptions` interface to match the runtime behavior documented in the schema.

## Schema Reference

From `lib/API/schema.json`:
```json
"port": {
  "type": "number",
  "docDescription": "Shortcut to inject a PORT environment variable"
}
```

## Changes

- Added `port?: number` property to `StartOptions` interface
- Added JSDoc comment matching the schema description

## Related Issue

Fixes #6045