### PR TITLE
refactor: replace mkdirp with native fs.mkdir recursive option

### DIFF
--- a/lib/API/Modules/NPM.js
+++ b/lib/API/Modules/NPM.js
@@ -1,5 +1,6 @@
 const path          = require('path');
 const fs            = require('fs');
+const fsPromises    = require('fs/promises');
 const os            = require('os');
 const spawn         = require('child_process').spawn;
 const chalk         = require('ansis');
@@ -211,7 +212,7 @@ function continueInstall(CLI, module_name, opts, cb) {
   var canonic_module_name = Utility.getCanonicModuleName(module_name);
   var install_path = path.join(cst.DEFAULT_MODULE_PATH, canonic_module_name);
 
-  require('mkdirp')(install_path)
+  fsPromises.mkdir(install_path, { recursive: true })
     .then(function() {
       process.chdir(os.homedir());
 

--- a/lib/API/Modules/TAR.js
+++ b/lib/API/Modules/TAR.js
@@ -86,7 +86,7 @@ function installLocal(PM2, module_filepath, opts, cb) {
 
     var install_path = path.join(cst.DEFAULT_MODULE_PATH, module_name);
 
-    require('mkdirp').sync(install_path)
+    fs.mkdirSync(install_path, { recursive: true })
 
     var install_instance = spawn('tar', ['zxf', module_filepath, '-C', install_path, '--strip-components 1'], {
       stdio : 'inherit',

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -130,7 +130,7 @@ Client.prototype.start = function(cb) {
 Client.prototype.initFileStructure = function (opts) {
   if (!fs.existsSync(opts.DEFAULT_LOG_PATH)) {
     try {
-      require('mkdirp').sync(opts.DEFAULT_LOG_PATH);
+      fs.mkdirSync(opts.DEFAULT_LOG_PATH, { recursive: true });
     } catch (e) {
       console.error(e.stack || e);
     }
@@ -138,7 +138,7 @@ Client.prototype.initFileStructure = function (opts) {
 
   if (!fs.existsSync(opts.DEFAULT_PID_PATH)) {
     try {
-      require('mkdirp').sync(opts.DEFAULT_PID_PATH);
+      fs.mkdirSync(opts.DEFAULT_PID_PATH, { recursive: true });
     } catch (e) {
       console.error(e.stack || e);
     }
@@ -154,7 +154,7 @@ Client.prototype.initFileStructure = function (opts) {
 
   if (!fs.existsSync(opts.DEFAULT_MODULE_PATH)) {
     try {
-      require('mkdirp').sync(opts.DEFAULT_MODULE_PATH);
+      fs.mkdirSync(opts.DEFAULT_MODULE_PATH, { recursive: true });
     } catch (e) {
       console.error(e.stack || e);
     }

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -241,7 +241,7 @@ Common.prepareAppConf = function(opts, app) {
         Common.printError(cst.PREFIX_MSG_WARNING + 'Folder does not exist: ' + dir);
         Common.printOut(cst.PREFIX_MSG + 'Creating folder: ' + dir);
         try {
-          require('mkdirp').sync(dir);
+          fs.mkdirSync(dir, { recursive: true });
         } catch (err) {
           Common.printError(cst.PREFIX_MSG_ERR + 'Could not create folder: ' + path.dirname(af));
           throw new Error('Could not create folder');

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eventemitter2": "5.0.1",
         "fclone": "1.0.11",
         "js-yaml": "4.1.1",
-        "mkdirp": "1.0.4",
         "needle": "2.4.0",
         "pidusage": "3.0.2",
         "pm2-axon": "~4.0.1",
@@ -1222,17 +1221,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/mocha": {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "enquirer": "2.3.6",
     "eventemitter2": "5.0.1",
     "fclone": "1.0.11",
-    "mkdirp": "1.0.4",
     "needle": "2.4.0",
     "pidusage": "3.0.2",
     "pm2-axon": "~4.0.1",


### PR DESCRIPTION
Replaces the `mkdirp` dependency with Node.js native `fs.mkdirSync({ recursive: true })` and `fs/promises.mkdir({ recursive: true })`.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A
