### PR TITLE
Fixed ridiculous default of using bun to run .ts files and removed ts-node/register entirely

### DIFF
--- a/lib/API/Modules/LOCAL.js
+++ b/lib/API/Modules/LOCAL.js
@@ -20,7 +20,7 @@ var INTERNAL_MODULES = {
   'event-loop-inspector': {name: 'event-loop-inspector'},
   'v8-profiler': {name: 'v8-profiler-node8'},
   'profiler': {name: 'v8-profiler-node8'},
-  'typescript': {dependencies: [{name: 'typescript'}, {name: 'ts-node@latest'}]},
+  'typescript': {dependencies: []},
   'livescript': {name: 'livescript'},
   'coffee-script': {name: 'coffee-script', message: 'Coffeescript v1 support'},
   'coffeescript': {name: 'coffeescript', message: 'Coffeescript v2 support'}

--- a/lib/API/interpreter.json
+++ b/lib/API/interpreter.json
@@ -7,6 +7,6 @@
   ".js"     : "node",
   ".coffee" : "coffee",
   ".ls"     : "lsc",
-  ".ts"     : "bun",
-  ".tsx"    : "bun"
+  ".ts"     : "node",
+  ".tsx"    : "node"
 }

--- a/lib/ProcessContainer.js
+++ b/lib/ProcessContainer.js
@@ -111,14 +111,6 @@ delete process.env.pm2_env;
  * @return
  */
 function exec(script, stds) {
-  if (p.extname(script) == '.ts' || p.extname(script) == '.tsx') {
-    try {
-      require('ts-node/register');
-    } catch (e) {
-      console.error('Failed to load Typescript interpreter:', e.message || e);
-    }
-  }
-
   process.on('message', function (msg) {
     if (msg.type === 'log:reload') {
       for (var k in stds){


### PR DESCRIPTION
PM2 has been broken for nodejs/typescript users for at least a year, this fixes it. https://github.com/Unitech/pm2/issues/6014

ts-node/register? gone. I don't want it. Node runs .ts files just fine. If it is needed put it behind some kind of config option.
bun? removed as the default for .ts files because this was undocumented behavior and frankly a rather ridiculous choice to force upon users.

