### PR TITLE
fix: CVE-2026-27699 update basic-ftp to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,9 +348,10 @@
       "dev": true
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -199,7 +199,8 @@
     "js-yaml": "4.1.1"
   },
   "overrides": {
-    "debug": "4.4.3"
+    "debug": "4.4.3",
+    "basic-ftp": "5.2.0"
   },
   "optionalDependencies": {
     "pm2-sysmonit": "^1.2.8"


### PR DESCRIPTION
## Summary

- Fixes **CVE-2026-27699** (critical vulnerability in `basic-ftp` < 5.2.0)
- Adds an npm `overrides` entry to pin `basic-ftp` to `5.2.0`
- The vulnerable dependency chain is: `@pm2/agent` -> `proxy-agent` -> `pac-proxy-agent` -> `get-uri` -> `basic-ftp@5.0.5`

Since `basic-ftp` is a transitive dependency and pm2 is typically installed globally (`npm i -g pm2`), users cannot resolve this with `npm audit fix` — it needs to be fixed in pm2 itself.

Closes #6088