### PR TITLE
fix: pm2 flush reports error for nonexistent process

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -28,8 +28,12 @@ module.exports = function(CLI) {
         Common.printError(err);
         return cb ? cb(Common.retErr(err)) : that.exitCli(cst.ERROR_EXIT);
       }
+
+      var found = false;
+
       list.forEach(function(l) {
         if (typeof api == 'undefined') {
+          found = true;
           Common.printOut(cst.PREFIX_MSG + 'Flushing:');
           Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_out_log_path);
           Common.printOut(cst.PREFIX_MSG + l.pm2_env.pm_err_log_path);
@@ -42,6 +46,7 @@ module.exports = function(CLI) {
           fs.closeSync(fs.openSync(l.pm2_env.pm_err_log_path, 'w'));
         }
         else if (l.pm2_env.pm_id == api || l.pm2_env.name === api) {
+          found = true;
           Common.printOut(cst.PREFIX_MSG + 'Flushing:');
 
           if (l.pm2_env.pm_log_path && fs.existsSync(l.pm2_env.pm_log_path)) {
@@ -61,7 +66,12 @@ module.exports = function(CLI) {
         }
       });
 
-      Common.printOut(cst.PREFIX_MSG + 'Logs flushed');
+      if (found) {
+        Common.printOut(cst.PREFIX_MSG + 'Logs flushed');
+      } else if (typeof api !== 'undefined') {
+        Common.printError(cst.PREFIX_MSG_ERR + 'No process found with name or id \'' + api + '\'');
+        return cb ? cb(Common.retErr('process not found')) : that.exitCli(cst.ERROR_EXIT);
+      }
       return cb ? cb(null, list) : that.exitCli(cst.SUCCESS_EXIT);
     });
   };

--- a/test/programmatic/flush.mocha.js
+++ b/test/programmatic/flush.mocha.js
@@ -77,5 +77,50 @@ describe('Programmatic flush feature test', function() {
         });
       });
     });
+    it('flush logs by pm_id', function(done) {
+      pm2.start({
+        script: './echo.js',
+        name: 'first',
+        error_file : 'error-first.log',
+        out_file   : 'out-first.log',
+        merge_logs: false
+      }, function(err, procs) {
+        should(err).be.null();
+        var out_file = procs[0].pm2_env.pm_out_log_path;
+        var err_file = procs[0].pm2_env.pm_err_log_path;
+        var pm_id = String(procs[0].pm2_env.pm_id);
+        pm2.start({
+            script: './001-test.js',
+            name: 'second',
+            error_file : 'error-second.log',
+            out_file   : 'out-second.log',
+            merge_logs: false
+          }, function(err, procs) {
+            should(err).be.null();
+            var out_file1 = procs[0].pm2_env.pm_out_log_path;
+            var err_file1 = procs[0].pm2_env.pm_err_log_path;
+            pm2.flush(pm_id, function(){
+              fs.readFileSync(out_file, "utf8").toString().should.be.empty();
+              fs.readFileSync(err_file, "utf8").toString().should.be.empty();
+              fs.readFileSync(out_file1, "utf8").toString().should.not.be.empty();
+              fs.readFileSync(err_file1, "utf8").toString().should.not.be.empty();
+              done();
+        });
+        });
+      });
+    });
+    it('should return error when process not found', function(done) {
+      pm2.start({
+        script: './echo.js',
+        name: 'myapp',
+        merge_logs: false
+      }, function(err) {
+        should(err).be.null();
+        pm2.flush('nonexistent', function(err) {
+          should(err).not.be.null();
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- When `pm2 flush <app_name>` or `pm2 flush <app_id>` targets a process that does not exist, PM2 now prints an error instead of silently printing "Logs flushed"
- Adds a `found` flag to track whether any process matched the given name/id
- Adds test coverage for pm_id-based flushing and the not-found error case

Previously, running `pm2 flush nonexistent` would print `[PM2] Logs flushed` even though no logs were actually flushed, giving the user misleading feedback.

## Test plan

- [x] `npm test` passes (flush.mocha.js)
- [x] Flush all (no argument) still works
- [x] Flush by app name works and only flushes that app
- [x] Flush by pm_id works and only flushes that process
- [x] Flush with nonexistent name/id returns an error

Closes #4553