### PR TITLE
fix(windows): use unique named pipe paths derived from PM2_HOME

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -81,10 +81,14 @@ module.exports = function(PM2_HOME) {
 
   if (process.platform === 'win32' ||
       process.platform === 'win64') {
-    //@todo instead of static unique rpc/pub file custom with PM2_HOME or UID
-    pm2_file_stucture.DAEMON_RPC_PORT = '\\\\.\\pipe\\rpc.sock';
-    pm2_file_stucture.DAEMON_PUB_PORT = '\\\\.\\pipe\\pub.sock';
-    pm2_file_stucture.INTERACTOR_RPC_PORT = '\\\\.\\pipe\\interactor.sock';
+    // Use PM2_HOME-based unique pipe names to avoid global collisions.
+    // Windows named pipes are kernel objects in a flat global namespace;
+    // hardcoded names cause EPERM when another user/session holds the pipe.
+    var crypto = require('crypto');
+    var pipeId = crypto.createHash('md5').update(PM2_HOME).digest('hex').slice(0, 8);
+    pm2_file_stucture.DAEMON_RPC_PORT = '\\\\.\\pipe\\pm2-' + pipeId + '-rpc.sock';
+    pm2_file_stucture.DAEMON_PUB_PORT = '\\\\.\\pipe\\pm2-' + pipeId + '-pub.sock';
+    pm2_file_stucture.INTERACTOR_RPC_PORT = '\\\\.\\pipe\\pm2-' + pipeId + '-interactor.sock';
   }
 
   return pm2_file_stucture;


### PR DESCRIPTION
## Problem

On Windows, PM2 hardcodes named pipe paths to `\.\pipe\rpc.sock`, `\.\pipe\pub.sock`, and `\.\pipe\interactor.sock` (in `paths.js` line 84-87). Since Windows named pipes live in a **flat global kernel namespace**, this causes `connect EPERM //./pipe/rpc.sock` errors when:

- **Multiple users** run PM2 on the same machine (#5510, #5212)
- A **zombie pipe** from a crashed daemon blocks the name (pipe outlives the process)
- PM2 is started from **different elevation levels** (admin PowerShell vs normal terminal) (#2946, #3859)

The code already had a `@todo` comment acknowledging this:
```js
//@todo instead of static unique rpc/pub file custom with PM2_HOME or UID
```

This issue has been reported since **2017** (#2946) and remains unfixed in PM2 6.0.14.

## Solution

Derive a short hash from `PM2_HOME` and embed it in the pipe name:

```js
var crypto = require('crypto');
var pipeId = crypto.createHash('md5').update(PM2_HOME).digest('hex').slice(0, 8);
pm2_file_stucture.DAEMON_RPC_PORT = '\\.\pipe\pm2-' + pipeId + '-rpc.sock';
pm2_file_stucture.DAEMON_PUB_PORT = '\\.\pipe\pm2-' + pipeId + '-pub.sock';
pm2_file_stucture.INTERACTOR_RPC_PORT = '\\.\pipe\pm2-' + pipeId + '-interactor.sock';
```

This ensures each `PM2_HOME` gets its own isolated set of IPC pipes, eliminating collisions.

## What this fixes

- Each user's PM2 instance uses unique pipe names based on their `PM2_HOME` path
- No more `EPERM` from zombie pipes blocking the global name
- Custom `PM2_HOME` directories work correctly on Windows
- Zero impact on Linux/macOS (they use Unix domain sockets with `PM2_HOME`-relative paths)

## Note

The **same hardcoded pipe names also exist** in `@pm2/agent` (`constants.js` line 93-96). That package needs a matching fix — happy to submit a PR there as well if you point me to the right repo.

## Tested on

- Windows 11 Pro (10.0.26200)
- Node.js v24.14.0
- PM2 6.0.14

Fixes #5510
Fixes #2946
Related: #5212, #3859, #4851