### PR TITLE
throw error if provided `cwd` doesn't exist

### DIFF
--- a/lib/Common.js
+++ b/lib/Common.js
@@ -145,6 +145,10 @@ Common.prepareAppConf = function(opts, app) {
   cwd && (cwd[0] != '/') && (cwd = path.resolve(process.cwd(), cwd));
   cwd = cwd || opts.cwd;
 
+  if (!fs.existsSync(cwd)) {
+    return new Error(`Provided cwd: "${cwd}" does not exist!`);
+  }
+
   // Full path script resolution
   app.pm_exec_path = path.resolve(cwd, app.script);
 

--- a/lib/Common.js
+++ b/lib/Common.js
@@ -146,7 +146,7 @@ Common.prepareAppConf = function(opts, app) {
   cwd = cwd || opts.cwd;
 
   if (!fs.existsSync(cwd)) {
-    return new Error(`Provided cwd: "${cwd}" does not exist!`);
+    return new Error(`No such directory, cwd '${cwd}'`);
   }
 
   // Full path script resolution

--- a/test/programmatic/programmatic.js
+++ b/test/programmatic/programmatic.js
@@ -95,6 +95,16 @@ describe('PM2 programmatic calls', function() {
       });
     });
 
+    it('should throw if cwd doesn\'t exist', function(done) {
+      pm2.start({
+        command: 'echo $PWD',
+        cwd: "./IMAGINARY_DIR",
+      }, function(err, data) {
+        should.exists(err);
+        done();
+      })
+    });
+
     it('should notice error if wrong file passed', function(done) {
       pm2.start('./UNKNOWN_SCRIPT.js', {
         force : true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

If pm2 is given an invalid `cwd`, it silently fails. The status keeps showing as process online, but the process doesn't start.

<img width="1107" height="1033" alt="ss01" src="https://github.com/user-attachments/assets/e33ca155-d1a3-493d-8927-ff58d46f04ca" />


This PR adds a check to make sure the provided `cwd` is valid, otherwise returns an error.
I have also added a test case for this.