### PR TITLE
fix: bump js-yaml from 4.1.1 to 4.2.0 (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "semver": "7.7.2",
     "vizion": "2.2.1",
     "ws": "8.20.0",
-    "js-yaml": "4.1.1"
+    "js-yaml": "4.2.0"
   },
   "overrides": {
     "debug": "4.4.3"


### PR DESCRIPTION
Bumps `js-yaml` from the exact-pinned **`4.1.1`** to **`4.2.0`**, which fixes [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) (quadratic-complexity DoS in merge key handling via repeated aliases).

`4.2.0` is a drop-in patch release on the same v4 API — no code changes required. Verified that pm2 loads cleanly with `js-yaml@4.2.0`.

Mirrors the exact-version style of #6117 (the companion `ws` advisory bump).

Closes #6122