### PR TITLE
Fix command/config injection in logrotate -u and startup --service-name (CWE-78/CWE-22, follow-up to #6089)

### DIFF
--- a/lib/API/LogManagement.js
+++ b/lib/API/LogManagement.js
@@ -89,6 +89,11 @@ module.exports = function(CLI) {
 
     var user = opts.user || 'root';
 
+    if (!/^[a-zA-Z0-9._-]+$/.test(user)) {
+      Common.printError(cst.PREFIX_MSG_ERR + 'Invalid -u/--user value: only alphanumeric, dot, underscore and dash are allowed');
+      return cb ? cb(Common.retErr('Invalid user value')) : that.exitCli(cst.ERROR_EXIT);
+    }
+
     script = script.replace(/%HOME_PATH%/g, cst.PM2_ROOT_PATH)
       .replace(/%USER%/g, user);
 

--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -77,6 +77,12 @@ module.exports = function(CLI) {
     var openrc_service_name = 'pm2';
     var launchd_service_name = (opts.serviceName || 'pm2.' + user);
 
+    if (!/^[a-zA-Z0-9._-]+$/.test(user) ||
+        (opts.serviceName && !/^[a-zA-Z0-9._-]+$/.test(opts.serviceName))) {
+      Common.printError(cst.PREFIX_MSG_ERR + 'Invalid -u/--user or --service-name value: only alphanumeric, dot, underscore and dash are allowed');
+      return cb ? cb(new Error('Invalid user or service name')) : that.exitCli(cst.ERROR_EXIT);
+    }
+
     if (!platform)
       platform = actual_platform;
     else if (actual_platform && actual_platform !== platform) {
@@ -202,6 +208,12 @@ module.exports = function(CLI) {
     var service_name = (opts.serviceName || 'pm2-' + user);
     var openrc_service_name = 'pm2';
     var launchd_service_name = (opts.serviceName || 'pm2.' + user);
+
+    if (!/^[a-zA-Z0-9._-]+$/.test(user) ||
+        (opts.serviceName && !/^[a-zA-Z0-9._-]+$/.test(opts.serviceName))) {
+      Common.printError(cst.PREFIX_MSG_ERR + 'Invalid -u/--user or --service-name value: only alphanumeric, dot, underscore and dash are allowed');
+      return cb ? cb(new Error('Invalid user or service name')) : that.exitCli(cst.ERROR_EXIT);
+    }
 
     if (!platform)
       platform = actual_platform;


### PR DESCRIPTION
## Summary

Two of the vulnerabilities reported in #6089 (items #5, #6, #7) were not addressed by the security
fixes shipped in v7.0.0 for the other items in that report. Since #6089 is already public (closed
issue, full technical detail visible), this PR fixes them directly rather than filing a new private
advisory.

- **`lib/API/LogManagement.js` — `pm2 logrotate -u <user>` (root only)**: the `user` value was
  concatenated unsanitized into both the logrotate template's `%USER%` substitution (embedded
  newlines let an attacker inject an arbitrary `postrotate`/`endscript` block, executed as root the
  next time logs rotate) and the destination path `/etc/logrotate.d/pm2-<user>` (path traversal once
  the value contains its own `/`, escaping the intended directory).
- **`lib/API/Startup.js` — `pm2 startup`/`unstartup --service-name <name>` (root only)**: the service
  name was concatenated unsanitized into shell command strings joined with `&& ` and passed to
  `sexec()` (`child_process.exec`, real shell), letting shell metacharacters (`;`, `#`, backticks,
  `$()`) execute arbitrary commands as root instead of being treated as a literal service/unit name.

Both are common patterns where the value in question is templated by provisioning/CI tooling from a
less-trusted source (hostname, tenant name, etc.) before being passed to a command that must run as
root.

## Fix

Both are fixed with the same minimal allowlist validation (`/^[a-zA-Z0-9._-]+$/`) already used
elsewhere in this codebase (e.g. `lib/tools/open.js`'s `SUDO_USER` check), rejecting path separators,
newlines and shell metacharacters before the value reaches the filesystem/shell sink. Legitimate
values (alphanumeric service/user names) are unaffected.

## Test plan

- [x] `node -c` syntax check on both modified files
- [x] Verified the malicious payloads from the original report are now rejected with a clear error,
      while legitimate values (`www-data`, `my-app-1`) still pass validation and reach the original
      code path — see harness output below (ran against the patched files, no root/real systemd
      touched):

```
[LogManagement] malicious -u rejected: YES (fixed)
[LogManagement] legitimate -u "www-data" still works: YES
[Startup] malicious --service-name rejected: YES (fixed)
[Startup] legitimate --service-name "my-app-1" passes validation: YES
```

- [ ] Would appreciate a maintainer re-running the project's `test/e2e/misc/startup.sh` (requires
      root + real init system, couldn't safely run destructively in my sandbox) to confirm no
      regression for the normal `pm2 startup`/`unstartup` flows.

Related: #6089