### PR TITLE
fix: repin js-yaml to 4.2.0 — 4.3.0 is gone from npm and breaks fresh installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "debug": "4.4.3",
     "eventemitter2": "6.4.9",
     "fast-json-patch": "3.1.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.2.0",
     "pidusage": "4.0.1",
     "pm2-deploy": "1.0.2",
     "proxy-agent": "6.5.0",


### PR DESCRIPTION
`npm install pm2` fails with ETARGET on 7.0.2/7.0.3 because the exact-pinned `js-yaml@4.3.0` no longer exists on the registry; the newest published version is 4.2.0, which is also the release GHSA-h67p-54hq-rp68 called for (#6122).

Fixes #6130

🤖 Generated with [Claude Code](https://claude.com/claude-code)