### PR TITLE
fix(cli): reload multiple process names

### DIFF
--- a/lib/binaries/CLI.js
+++ b/lib/binaries/CLI.js
@@ -416,10 +416,20 @@ commander.command('profile:cpu [time]')
 //
 // Reload process(es)
 //
-commander.command('reload <id|name|namespace|all>')
+commander.command('reload <id|name|namespace|all...>')
   .description('reload processes (note that its for app using HTTP/HTTPS)')
-  .action(function(pm2_id) {
-    pm2.reload(pm2_id, commander);
+  .action(function(param) {
+    // Commander.js patch
+    param = patchCommanderArg(param);
+    let acc = []
+    forEachLimit(param, 1, function(script, next) {
+      pm2.reload(script, commander, (err, apps) => {
+        acc = acc.concat(apps)
+        next(err)
+      });
+    }, function(err) {
+      pm2.speedList(err ? 1 : 0, acc);
+    });
   });
 
 commander.command('id <name>')

--- a/test/e2e/cli/multiparam.sh
+++ b/test/e2e/cli/multiparam.sh
@@ -14,6 +14,10 @@ $pm2 restart child echo server
 should 'should app be online' 'online' 3
 should 'should all script been restarted one time' 'restart_time: 1' 3
 
+## Reload
+$pm2 reload child echo server
+should 'should all script been restarted two times' 'restart_time: 2' 3
+
 ## Stop
 $pm2 stop child echo server
 should 'should app be stopped' 'stopped' 3


### PR DESCRIPTION
`pm2 reload a b` silently dropped every name after the first: the reload command was declared `<id|name|namespace|all>` while `stop`/`restart` are variadic, so commander discarded the extra names. This mirrors restart's `forEachLimit` loop (sequential, which reload's internal lock requires) and adds a multi-name reload case to the multiparam e2e — without the CLI change that case can't pass, since the dropped apps' restart_time never increments.

Fixes #6132

🤖 Generated with [Claude Code](https://claude.com/claude-code)