### PR TITLE
fix(cli): add start-or-reload kebab-case alias

### DIFF
--- a/lib/binaries/CLI.js
+++ b/lib/binaries/CLI.js
@@ -328,7 +328,8 @@ commander.command('startOrRestart <json>')
     pm2._startJson(file, commander, 'restartProcessId');
   });
 
-commander.command('startOrReload <json>')
+commander.command('start-or-reload <json>')
+  .alias('startOrReload')
   .description('start or gracefully reload JSON file')
   .action(function(file) {
     pm2._startJson(file, commander, 'reloadProcessId');


### PR DESCRIPTION
## Summary
- Prefer `start-or-reload` as the CLI command name so it matches other kebab-style PM2 commands.
- Keep `startOrReload` as an alias so existing scripts and docs keep working.

Fixes #6107

## Test plan
- [ ] `pm2 start-or-reload ecosystem.config.js` runs the same path as before
- [ ] `pm2 startOrReload ecosystem.config.js` still works via the alias
- [ ] `pm2 --help` lists `start-or-reload`