### PR TITLE
feat: view full log line in monit dashboard

### DIFF
--- a/lib/API/Dashboard.js
+++ b/lib/API/Dashboard.js
@@ -36,6 +36,12 @@ Dashboard.init = function() {
   this.screen.title = 'PM2 Dashboard';
 
   this.logLines = {}
+  // Parallel to logLines (display strings with color tags), but holding
+  // the untruncated raw text + metadata for each line so the detail
+  // overlay (see showLogDetail) can show more than what fits in logBox's
+  // fixed-width, non-wrapping list rendering.
+  this.rawLogLines = {}
+  this.currentProcessId = null
 
   this.list = blessed.list({
     top: '0',
@@ -76,6 +82,11 @@ Dashboard.init = function() {
     this.logBox.clearItems()
   })
 
+  // NOTE for pm2 maintainers: `select` only fires on Enter (List.enterSelected),
+  // unlike `select item` which fires on every up/down navigation too
+  // (List.prototype.select) — see widgets/list.js. That distinction is what
+  // makes it safe to open a heavyweight detail overlay here without it
+  // popping open on every arrow-key scroll or refresh-driven setItems() call.
   this.logBox = blessed.list({
     label: ' Logs ',
     top: '0',
@@ -104,6 +115,10 @@ Dashboard.init = function() {
         fg: 'black'
       }
     }
+  });
+
+  this.logBox.on('select', (item, index) => {
+    this.showLogDetail(index);
   });
 
   this.metadataBox = blessed.box({
@@ -166,7 +181,7 @@ Dashboard.init = function() {
   });
 
   this.box4 = blessed.text({
-    content: ' left/right: switch boards | up/down/mouse: scroll | Ctrl-C: exit{|} {cyan-fg}{bold}To go further check out https://pm2.io/{/}  ',
+    content: ' left/right: switch boards | up/down/mouse: scroll | enter on a log line: view full line | Ctrl-C: exit{|} {cyan-fg}{bold}To go further check out https://pm2.io/{/}  ',
     left: '0%',
     top: '95%',
     width: '100%',
@@ -178,6 +193,48 @@ Dashboard.init = function() {
     }
   });
 
+  // Overlay shown on top of everything else when a log line is opened via
+  // Enter in logBox (see showLogDetail). Hidden by default. A plain `box`
+  // (not `list`) is used deliberately so text wraps instead of clipping —
+  // that's the whole point vs. logBox's one-line-per-item rendering.
+  this.detailBox = blessed.box({
+    label: ' Log Line Detail (Enter to close) ',
+    top: 'center',
+    left: 'center',
+    width: '84%',
+    height: '70%',
+    padding: DEFAULT_PADDING,
+    scrollable: true,
+    alwaysScroll: true,
+    scrollbar: {
+      ch: ' ',
+      inverse: false
+    },
+    keys: true,
+    tags: true,
+    wrap: true,
+    hidden: true,
+    border: {
+      type: 'line'
+    },
+    style: {
+      fg: 'white',
+      border: {
+        fg: 'yellow'
+      },
+      scrollbar: {
+        bg: 'blue',
+        fg: 'black'
+      }
+    }
+  });
+
+  this.detailBox.key(['enter'], () => {
+    this.detailBox.hide();
+    this.logBox.focus();
+    this.screen.render();
+  });
+
   this.list.focus();
 
   this.screen.append(this.list);
@@ -185,6 +242,7 @@ Dashboard.init = function() {
   this.screen.append(this.metadataBox);
   this.screen.append(this.metricsBox);
   this.screen.append(this.box4);
+  this.screen.append(this.detailBox);
 
   this.list.setLabel(' Process List ');
 
@@ -294,6 +352,7 @@ Dashboard.refresh = function(processes) {
     var proc = processes[this.list.selected];
     // render the logBox
     let process_id = proc.pm_id
+    this.currentProcessId = process_id
     let logs = this.logLines[process_id];
     if(typeof(logs) !== "undefined"){
       this.logBox.setItems(logs)
@@ -362,6 +421,9 @@ Dashboard.log = function(type, data) {
   if(typeof(this.logLines[data.process.pm_id]) == "undefined"){
     this.logLines[data.process.pm_id]=[];
   }
+  if(typeof(this.rawLogLines[data.process.pm_id]) == "undefined"){
+    this.rawLogLines[data.process.pm_id]=[];
+  }
   // Logs colors
   switch (type) {
     case 'PM2':
@@ -382,6 +444,19 @@ Dashboard.log = function(type, data) {
   logs.forEach((log) => {
     if (log.length > 0) {
       this.logLines[data.process.pm_id].push(color + data.process.name + '{/} > ' + log)
+      this.rawLogLines[data.process.pm_id].push({
+        // Loggers like Winston wrap level words in raw ANSI SGR codes
+        // (e.g. "\x1b[32minfo\x1b[39m:") when they think they're writing to
+        // a TTY. Left in place, the escape sequence's trailing letter (the
+        // "m" in "\x1b[32m") sits directly against the level word with no
+        // word boundary between them, which silently breaks the \b-based
+        // detection in showLogDetail. Stripping them also happens to make
+        // the detail view's "Full line" cleaner to read.
+        text: stripAnsiCodes(log),
+        type: type,
+        processName: data.process.name,
+        receivedAt: new Date()
+      })
 
 
       //removing logs if longer than limit
@@ -399,6 +474,7 @@ Dashboard.log = function(type, data) {
 
       if (count > 200) {
         this.logLines[leading_process_id].shift()
+        this.rawLogLines[leading_process_id].shift()
       }
     }
   })
@@ -406,7 +482,76 @@ Dashboard.log = function(type, data) {
   return this;
 }
 
+/**
+ * Show the full, untruncated text (+ metadata) of one logBox line in the
+ * detail overlay. Triggered by pressing Enter on a selected line in logBox.
+ * @method showLogDetail
+ * @param {Number} index index of the line within the currently displayed
+ *                        process's log buffer (matches logBox's own item
+ *                        order, since both are built from the same array)
+ * @return this
+ */
+Dashboard.showLogDetail = function(index) {
+  var entries = this.rawLogLines[this.currentProcessId];
+  if (!entries || !entries[index]) {
+    return this;
+  }
+
+  var entry = entries[index];
+
+  var streamLabels = {
+    PM2: 'pm2 (internal)',
+    out: 'stdout',
+    err: 'stderr'
+  };
+  var streamLabel = streamLabels[entry.type] || entry.type;
+
+  // Best-effort: most log lines here are already prefixed by whatever
+  // logging library the app uses (Winston, pino, console, pm2 itself...),
+  // not by pm2 itself, so this is just a convenience guess, not a
+  // guarantee - shown as "(none detected)" when it doesn't match.
+  var tsMatch = entry.text.match(/^\[?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})\S*\]?:?\s*/);
+  var detectedTimestamp = tsMatch ? tsMatch[1] : null;
+  var remainder = tsMatch ? entry.text.slice(tsMatch[0].length) : entry.text;
+
+  var levelMatch = remainder.match(/\b(fatal|error|warn(?:ing)?|info|notice|debug|trace)\b/i);
+  var detectedLevel = levelMatch ? levelMatch[1].toLowerCase() : null;
+  var levelColors = {
+    fatal: 'red', error: 'red', warn: 'yellow', warning: 'yellow',
+    info: 'green', notice: 'cyan', debug: 'blue', trace: 'white'
+  };
+  var levelColor = levelColors[detectedLevel] || 'white';
+
+  var lines = [
+    '{bold}Process{/}        ' + entry.processName,
+    '{bold}Stream{/}         ' + streamLabel,
+    '{bold}Received at{/}    ' + entry.receivedAt.toLocaleString(),
+    '{bold}Log timestamp{/}  ' + (detectedTimestamp || '{grey-fg}(none detected in line){/}'),
+    '{bold}Log level{/}      ' + (detectedLevel
+      ? '{' + levelColor + '-fg}{bold}' + detectedLevel.toUpperCase() + '{/}'
+      : '{grey-fg}(none detected in line){/}'),
+    '',
+    '{underline}Full line{/}',
+    entry.text
+  ];
+
+  this.detailBox.setContent(lines.join('\n'));
+  this.detailBox.scrollTo(0);
+  this.detailBox.show();
+  this.detailBox.setFront();
+  this.detailBox.focus();
+  this.screen.render();
+
+  return this;
+};
+
 module.exports = Dashboard;
+
+// eslint-disable-next-line no-control-regex
+var ANSI_RE = /\x1b\[[0-9;]*m/g;
+function stripAnsiCodes(str) {
+  return str.replace(ANSI_RE, '');
+}
 
 function timeSince(date) {
 


### PR DESCRIPTION
## Problem

The Logs panel in `pm2 monit` / `pm2 dashboard` (`lib/API/Dashboard.js`)
renders each entry as one row in a `blessed.list`. Anything wider than the
panel is silently clipped, with no way to see the rest — no wrapping, no
horizontal scroll, no detail view. Long lines (stack traces, JSON payloads,
long URLs, etc.) are simply unreadable in the dashboard today.

## What this adds

Pressing **Enter** on a selected line in the Logs panel opens a scrollable
overlay with:
- The full, wrapped, untruncated text of that line
- Process name
- Stream (`stdout` / `stderr` / pm2-internal)
- When the dashboard received it
- A best-effort detected timestamp and log level, parsed out of the line's
  own text (many apps prefix their own lines with these, independent of
  pm2's stream typing)

Pressing Enter again closes the overlay and returns focus to the Logs panel.
The footer hint text is updated accordingly.

## Implementation notes

- A parallel `rawLogLines` buffer stores untruncated text + metadata per
  line, evicted in lockstep with the existing `logLines` (display strings)
  buffer, so memory usage is unaffected.
- The overlay listens for `List`'s `select` event (emitted only from
  `enterSelected`, i.e. an explicit Enter), not `select item` (emitted on
  every navigation via `List.prototype.select`, including the refresh-driven
  `setItems()` calls) — so it only opens on Enter, never as a side effect of
  scrolling or the dashboard's periodic refresh tick.
- Log text coming through loggers like Winston can carry raw ANSI SGR codes
  around level words (e.g. `"\x1b[32minfo\x1b[39m:"`). Left in place, the
  escape sequence's trailing letter sits directly against the word with no
  regex word boundary between them, silently breaking level detection — so
  these are stripped before storage.

## Testing

This file has no existing automated test coverage (it's a `blessed`
terminal UI with no headless test harness in this repo). I tested manually
via `tmux` (driving the real interactive dashboard with `tmux send-keys` /
`capture-pane` against live `pm2`-managed processes) and via a small
synthetic harness that calls `Dashboard.init()` / `.log()` /
`.showLogDetail()` directly to exercise ANSI-stripping and level-detection
against realistic Winston-colorized output. Verified:
- Long lines (a 2000+ char JSON line) render fully wrapped in the overlay
- Enter opens/closes the overlay correctly and returns focus to the Logs
  panel
- Up/down scroll works inside the overlay for content taller than it
- Detected timestamp/level render correctly, including with ANSI-colorized
  input
- No regressions to existing board-switching (left/right) or quit
  (Escape/q/Ctrl-C) behavior

Made with [Cursor](https://cursor.com)