### PR TITLE
feat: show host metrics speedbar in monit dashboard

### DIFF
--- a/lib/API/Dashboard.js
+++ b/lib/API/Dashboard.js
@@ -37,6 +37,11 @@ Dashboard.init = function() {
 
   this.logLines = {}
 
+  // Tracks which footer layout (see setSpeedbarLayout) is currently
+  // active. Starts false to match the widgets' own initial values below
+  // (metadataBox/metricsBox at 26%, box4 at 95%/6%, speedbarBox hidden).
+  this.speedbarLayoutActive = false
+
   this.list = blessed.list({
     top: '0',
     left: '0',
@@ -111,7 +116,16 @@ Dashboard.init = function() {
     top: '70%',
     left: WIDTH_LEFT_PANEL + '%',
     width: 100 - WIDTH_LEFT_PANEL + '%',
-    height: '26%',
+    // Height is toggled at runtime between '25%' (no speedbar) and '21%'
+    // (speedbar visible, its ~5% carved out of this panel) by
+    // setSpeedbarLayout() below. 25%, not pm2's original 26%: stock pm2 has
+    // this panel ending at 70+26=96%, one point past box4's own top (95%),
+    // so at certain terminal row counts (rounding-dependent - e.g. exactly
+    // 50 rows; most other row counts happen to round away from it) box4
+    // paints over this panel's bottom border row since it's appended after
+    // it. 25% closes that gap everywhere instead of only at the specific
+    // sizes stock pm2's rounding happens to dodge it at.
+    height: '25%',
     padding: DEFAULT_PADDING,
     scrollable: true,
     scrollbar: {
@@ -141,7 +155,8 @@ Dashboard.init = function() {
     top: '70%',
     left: '0%',
     width: WIDTH_LEFT_PANEL + '%',
-    height: '26%',
+    // See matching comment on metadataBox above.
+    height: '25%',
     padding: DEFAULT_PADDING,
     scrollbar: {
       ch: ' ',
@@ -168,11 +183,40 @@ Dashboard.init = function() {
   this.box4 = blessed.text({
     content: ' left/right: switch boards | up/down/mouse: scroll | Ctrl-C: exit{|} {cyan-fg}{bold}To go further check out https://pm2.io/{/}  ',
     left: '0%',
+    // top/height toggled at runtime between '95%'/'5%' (no speedbar) and
+    // '91%'/'4%' (speedbar visible) by setSpeedbarLayout() below. Stock
+    // pm2 uses '95%'/'6%' here (ending at 101%, one past the screen and
+    // one past metadataBox/metricsBox's own bottom edge - see comment on
+    // metadataBox above for why that 1% causes a missing-border glitch at
+    // some terminal sizes); '5%' ends exactly at 100% with zero overlap.
     top: '95%',
     width: '100%',
-    height: '6%',
+    height: '5%',
     valign: 'middle',
     tags: true,
+    style: {
+      fg: 'white'
+    }
+  });
+
+  // Host metrics line ("speedbar"), same data/format as the `host metrics`
+  // row `pm2 status`/`pm2 ls` prints when `pm2:sysmonit` is enabled (see
+  // lib/API/UX/pm2-ls.js's miniMonitBar - buildSpeedbarLine below is that
+  // same logic, rendered with blessed content tags instead of chalk/ansis
+  // escape codes). Starts hidden; refreshSystemData() shows it (and grows
+  // metadataBox/metricsBox's neighboring layout to make room, via
+  // setSpeedbarLayout()) the moment a non-empty getSystemData response
+  // arrives, and hides it again the moment one isn't - e.g. `pm2:sysmonit`
+  // is off - so there's no reserved dead space when there's nothing to show.
+  this.speedbarBox = blessed.text({
+    content: '',
+    left: '0%',
+    top: '95%',
+    width: '100%',
+    height: '5%',
+    valign: 'middle',
+    tags: true,
+    hidden: true,
     style: {
       fg: 'white'
     }
@@ -185,6 +229,7 @@ Dashboard.init = function() {
   this.screen.append(this.metadataBox);
   this.screen.append(this.metricsBox);
   this.screen.append(this.box4);
+  this.screen.append(this.speedbarBox);
 
   this.list.setLabel(' Process List ');
 
@@ -406,6 +451,26 @@ Dashboard.log = function(type, data) {
   return this;
 }
 
+/**
+ * Refresh the host metrics ("speedbar") line below the help bar.
+ * @method refreshSystemData
+ * @param {Object} systemdata result of the `getSystemData` remote call -
+ *                             empty/absent whenever `pm2:sysmonit` is off
+ * @return this
+ */
+Dashboard.refreshSystemData = function(systemdata) {
+  if (!this.speedbarBox) {
+    return this;
+  }
+
+  var line = buildSpeedbarLine(systemdata);
+  setSpeedbarLayout(this, line !== '');
+  this.speedbarBox.setContent(line);
+  this.screen.render();
+
+  return this;
+};
+
 module.exports = Dashboard;
 
 function timeSince(date) {
@@ -434,6 +499,179 @@ function timeSince(date) {
     return interval + 'm';
   }
   return Math.floor(seconds) + 's';
+}
+
+// Flips the footer between two fixed layouts: metadataBox/metricsBox at
+// their original 26% (no speedbar - box4 back at its original 95%/6%,
+// speedbarBox hidden) vs. 21% (speedbar visible in the ~5% carved out
+// below box4). Called from refreshSystemData() only when the on/off state
+// actually changes, so metadataBox/metricsBox get their space back
+// instead of leaving a permanent dead gap whenever `pm2:sysmonit` is off.
+function setSpeedbarLayout(dashboard, showSpeedbar) {
+  if (dashboard.speedbarLayoutActive === showSpeedbar) {
+    return;
+  }
+  dashboard.speedbarLayoutActive = showSpeedbar;
+
+  if (showSpeedbar) {
+    dashboard.metadataBox.height = '21%';
+    dashboard.metricsBox.height = '21%';
+    dashboard.box4.top = '91%';
+    dashboard.box4.height = '4%';
+    dashboard.speedbarBox.show();
+  } else {
+    dashboard.metadataBox.height = '25%';
+    dashboard.metricsBox.height = '25%';
+    dashboard.box4.top = '95%';
+    dashboard.box4.height = '5%';
+    dashboard.speedbarBox.hide();
+  }
+
+  // blessed's render() normally does an incremental diff against the
+  // previous frame's cell buffer and only repaints changed cells - fine
+  // for content updates, but when a box's own dimensions shrink/grow, the
+  // old frame's characters just outside the new bounds (border lines,
+  // trailing metadata rows, etc.) were never marked dirty and won't get
+  // erased on the next render(). realloc() resets those buffers so this
+  // one screen.render() (called by refreshSystemData right after this
+  // function returns) does a full clean repaint. Only happens on an
+  // actual on/off transition, not every poll.
+  dashboard.screen.realloc();
+}
+
+// blessed-tag equivalent of UxHelpers.colorizedMetric (lib/API/UX/helpers.js),
+// which returns chalk/ansis-colored strings - not usable here since this
+// content goes through blessed's own {tag} styling, not raw ANSI escapes.
+// Same green/yellow/red threshold semantics, including the "lower is worse"
+// inversion (e.g. RAM Available) when alert < warn.
+function colorizeMetric(value, warn, alert, suffix) {
+  suffix = suffix || '';
+
+  if (isNaN(value)) {
+    return 'N/A';
+  }
+  if (Number(value) == 0) {
+    return '0' + suffix;
+  }
+
+  var inverted = alert < warn;
+  var danger = inverted ? (value <= alert) : (value >= alert);
+  var caution = inverted ? (value <= warn && value > alert) : (value >= warn && value < alert);
+
+  if (danger) {
+    return '{red-fg}{bold}' + value + suffix + '{/}';
+  }
+  if (caution) {
+    return '{yellow-fg}{bold}' + value + suffix + '{/}';
+  }
+  return '{green-fg}' + value + suffix + '{/}';
+}
+
+// Builds the single-line host metrics summary shown in speedbarBox. Ported
+// from miniMonitBar() in lib/API/UX/pm2-ls.js (the same data backs the
+// `host metrics` row `pm2 status`/`pm2 ls` prints), with chalk/ansis output
+// swapped for blessed content tags. Keep the two in sync if one changes.
+function buildSpeedbarLine(m) {
+  if (!m || Object.keys(m).length === 0) {
+    return '';
+  }
+
+  var cpu = m['CPU Usage'];
+  if (typeof cpu === 'undefined') {
+    return '';
+  }
+
+  var line = '{bold}{cyan-fg}host metrics{/} ';
+  line += '| {bold}cpu{/}: ' + colorizeMetric(cpu.value, 40, 70, '%');
+
+  var temp = m['CPU Temperature'] ? m['CPU Temperature'].value : null;
+  if (temp && temp != '-1') {
+    line += ' ' + colorizeMetric(temp, 50, 70, 'º');
+  }
+
+  var ramUsage = m['RAM Usage'] ? m['RAM Usage'].value : null;
+  if (ramUsage === null) {
+    var memTotal = m['RAM Total'] ? m['RAM Total'].value : null;
+    var memAvailable = m['RAM Available'] ? m['RAM Available'].value : null;
+    if (memTotal) {
+      ramUsage = (100 - ((memAvailable / memTotal) * 100)).toFixed(1);
+    }
+  }
+  if (ramUsage !== null && typeof ramUsage !== 'undefined') {
+    line += ' | {bold}ram usage{/}: ' + colorizeMetric(ramUsage, 70, 90, '%');
+  }
+
+  if (m['graphics:mem:total'] && Number(m['graphics:mem:total'].value) > 0) {
+    var gpuTotal = m['graphics:mem:total'].value;
+    var gpuUsed = m['graphics:mem:used'] ? m['graphics:mem:used'].value : 0;
+    line += ' | {bold}gpu{/}: ' + gpuUsed + '/' + gpuTotal + 'mb';
+    var gpuTemp = m['graphics:temp'] ? m['graphics:temp'].value : null;
+    if (gpuTemp && gpuTemp != '-1') {
+      line += ' ' + colorizeMetric(gpuTemp, 50, 70, 'º');
+    }
+  }
+
+  var interfaces = Object.keys(m).filter(function(k) {
+    return k.indexOf('net') !== -1 && k !== 'net:default';
+  }).map(function(k) {
+    return k.split(':')[2];
+  }).filter(function(iface, i, self) {
+    return self.indexOf(iface) === i;
+  });
+
+  interfaces.forEach(function(iface) {
+    if (!m['net:rx_5:' + iface]) {
+      return;
+    }
+    var rx = m['net:rx_5:' + iface].value;
+    var tx = m['net:tx_5:' + iface] ? m['net:tx_5:' + iface].value : 0;
+    // Only show interfaces actually carrying traffic
+    if (!(Number(rx) > 0 || Number(tx) > 0)) {
+      return;
+    }
+    line += ' | {bold}' + iface + '{/}: ';
+    line += '⇓ ' + colorizeMetric(rx, 10, 20, 'mb/s') + ' ';
+    line += '⇑ ' + colorizeMetric(tx, 10, 20, 'mb/s');
+
+    var rxErr = m['net:rx_errors_60:' + iface] ? Number(m['net:rx_errors_60:' + iface].value) : 0;
+    var txErr = m['net:tx_errors_60:' + iface] ? Number(m['net:tx_errors_60:' + iface].value) : 0;
+    var rxDrop = m['net:rx_dropped_60:' + iface] ? Number(m['net:rx_dropped_60:' + iface].value) : 0;
+    var txDrop = m['net:tx_dropped_60:' + iface] ? Number(m['net:tx_dropped_60:' + iface].value) : 0;
+    if (rxErr + txErr > 0) {
+      line += ' {bold}err{/} ' + colorizeMetric(rxErr + txErr, 1, 10, '/min');
+    }
+    if (rxDrop + txDrop > 0) {
+      line += ' {bold}drop{/} ' + colorizeMetric(rxDrop + txDrop, 1, 10, '/min');
+    }
+  });
+
+  if (m['Disk Reads']) {
+    var read = m['Disk Reads'].value;
+    var write = m['Disk Writes'] ? m['Disk Writes'].value : 0;
+
+    line += ' | {bold}disk{/}: ⇓ ' + colorizeMetric(read, 10, 20, 'mb/s');
+    line += ' ⇑ ' + colorizeMetric(write, 10, 20, 'mb/s');
+
+    var disks = Object.keys(m).filter(function(k) {
+      return k.indexOf('fs:') !== -1;
+    }).map(function(k) {
+      return k.split(':')[2];
+    }).filter(function(fs, i, self) {
+      return self.indexOf(fs) === i;
+    });
+
+    disks.forEach(function(fs) {
+      if (!m['fs:use:' + fs]) {
+        return;
+      }
+      var use = m['fs:use:' + fs].value;
+      if (use > 60) {
+        line += ' {grey-fg}' + fs + '{/} ' + colorizeMetric(use, 80, 90, '%');
+      }
+    });
+  }
+
+  return line;
 }
 
 /* Args :

--- a/lib/API/Extra.js
+++ b/lib/API/Extra.js
@@ -684,7 +684,27 @@ module.exports = function(CLI) {
       });
     }
 
+    // Host metrics ("speedbar", same data `pm2 status`/`pm2 ls` shows when
+    // `pm2:sysmonit` is enabled) come from a separate remote call and are a
+    // daemon-wide snapshot independent of any one process, so they're
+    // polled on their own slower cadence rather than piggybacking on
+    // refreshDashboard's 800ms per-process loop. A missing/empty response
+    // (sysmonit disabled, or not yet available) just leaves the bar blank -
+    // same as pm2-ls.js does for `pm2 status`.
+    function refreshSystemData() {
+      that.Client.executeRemote('getSystemData', {}, function(err, systemdata) {
+        if (!err) {
+          Dashboard.refreshSystemData(systemdata);
+        }
+
+        setTimeout(function() {
+          refreshSystemData();
+        }, 2000);
+      });
+    }
+
     refreshDashboard();
+    refreshSystemData();
   };
 
   CLI.prototype.monit = function(cb) {


### PR DESCRIPTION
## What

`pm2 status`/`pm2 ls` already print a "host metrics" line (CPU, RAM, disk, network, etc.) when `pm2:sysmonit` is enabled, but `pm2 monit`/`pm2 dashboard` never showed it, even though the same `getSystemData` data is available there too. This adds the same line to the dashboard, directly below the existing help/shortcuts bar.

## Details

- `lib/API/Extra.js`: `dashboard()` now also polls `getSystemData` on its own 2s interval (independent of the existing 800ms per-process `getMonitorData` poll, since host metrics are a daemon-wide snapshot, not per-process) and forwards the result to `Dashboard.refreshSystemData()`.
- `lib/API/Dashboard.js`:
  - New `speedbarBox` widget, hidden by default.
  - New `Dashboard.refreshSystemData()` renders the line (ported from `miniMonitBar()` in `lib/API/UX/pm2-ls.js`, same thresholds/colors, just blessed content tags instead of chalk/ansis) and calls a new `setSpeedbarLayout()` helper.
  - `setSpeedbarLayout()` toggles between two fixed layouts so the bar only takes up space when there's actually data to show: when `pm2:sysmonit` is off (or hasn't reported yet), `metadataBox`/`metricsBox`/`box4` sit exactly where they do today and `speedbarBox` is hidden - no permanent dead space. When data arrives, `metadataBox`/`metricsBox` shrink slightly and `box4` moves up to make room for the bar. `screen.realloc()` is called on each transition so blessed does a full repaint instead of leaving stale borders/content from the previous layout (its incremental diff render only marks cells dirty on content changes, not dimension changes).
  - While sizing the new layout, this also happens to fix a pre-existing cosmetic bug: `box4`'s stock `top: '95%', height: '6%'` ends at 101%, one point past both the screen and past `metadataBox`/`metricsBox`'s own bottom edge (`70% + 26%` = 96%). At certain terminal row counts (rounding-dependent, e.g. exactly 50 rows) that 1% overlap causes `box4` to paint over the bottom border of the metadata/custom metrics panels, since it's appended after them. Both states now use 25%/5% instead of 26%/6%, which closes the gap everywhere rather than only at the row counts stock pm2's rounding happens to dodge it at.

## Testing

Manually verified against a scratch `PM2_HOME` in a tmux session at a few terminal sizes:
- `pm2:sysmonit` on: speedbar renders below the help line with correct data/colors, no border clipping.
- `pm2:sysmonit` off: layout matches current stock pm2 exactly, no empty reserved line.
- Toggling on/off (via daemon restart) transitions cleanly with no stale artifacts.

Happy to add/adjust automated coverage if there's a preferred pattern for dashboard/blessed-UI tests in this repo - I didn't see existing ones to follow for `lib/API/Dashboard.js`.

Made with [Cursor](https://cursor.com)