### PR TITLE
feat(startup): embed Bun runtime in generated init script when running under Bun

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -16,6 +16,22 @@ var which        = require('../tools/which.js');
 var sexec = require('../tools/sexec')
 module.exports = function(CLI) {
   /**
+   * Return the pm2 executable path to embed in the startup command hint
+   * and in the generated init script.
+   *
+   * When PM2 runs under Bun (cst.IS_BUN), prefix the pm2 binary path with
+   * the Bun runtime (process.execPath). Without this, the init script would
+   * start the PM2 daemon with the shebang interpreter (node), which breaks
+   * cluster mode for Bun applications ("Unknown file extension .ts").
+   */
+  function getPm2ExecPath(pm2_bin_path) {
+    if (cst.IS_BUN === true) {
+      return process.execPath + ' ' + pm2_bin_path;
+    }
+    return pm2_bin_path;
+  }
+
+  /**
    * If command is launched without root right
    * Display helper
    */
@@ -28,12 +44,14 @@ module.exports = function(CLI) {
       pm2_bin_path = pm2_bin_path.replace('/lib/binaries/CLI.js', '/bin/pm2')
     }
 
+    let pm2_exec = getPm2ExecPath(pm2_bin_path)
+
     if (opts.user) {
-      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' pm2 ' + opts.args[1].name() + ' ' + platform + ' -u ' + opts.user + ' --hp ' + process.env.HOME);
+      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' ' + pm2_exec + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + opts.user + ' --hp ' + process.env.HOME);
       return cb(new Error('You have to run this with elevated rights'));
     }
     return sexec('whoami', {silent: true}, function(err, stdout, stderr) {
-      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' ' + pm2_bin_path + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + stdout.trim() + ' --hp ' + process.env.HOME);
+      console.log('sudo env PATH=$PATH:' + path.dirname(process.execPath) + ' ' + pm2_exec + ' ' + opts.args[1].name() + ' ' + platform + ' -u ' + stdout.trim() + ' --hp ' + process.env.HOME);
       return cb(new Error('You have to run this with elevated rights'));
     });
   }
@@ -349,7 +367,11 @@ module.exports = function(CLI) {
       pm2_bin_path = pm2_bin_path.replace('/lib/binaries/CLI.js', '/bin/pm2')
     }
 
-    template = template.replace(/%PM2_PATH%/g, pm2_bin_path)
+    // When running under Bun, embed the Bun runtime in the init script so the
+    // daemon is spawned with Bun (cluster mode support for Bun apps).
+    let pm2_exec = getPm2ExecPath(pm2_bin_path)
+
+    template = template.replace(/%PM2_PATH%/g, pm2_exec)
       .replace(/%NODE_PATH%/g, envPath)
       .replace(/%USER%/g, user)
       .replace(/%HOME_PATH%/g, opts.hp ? path.resolve(opts.hp, '.pm2') : cst.PM2_ROOT_PATH)


### PR DESCRIPTION
## Summary

When PM2 is run under Bun (`cst.IS_BUN`), the `pm2 startup` command now embeds the Bun runtime (`process.execPath`) in front of the pm2 binary path — both in the copy/paste command hint and in the generated init script (`%PM2_PATH%`).

Without this, the init script starts the PM2 daemon with the shebang interpreter (`node`), which breaks **cluster mode for Bun applications**:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for app.ts
```

## Before / After

Running `pm2 startup` under Bun now generates:

```ini
# Before (shebang decides → daemon starts with node)
ExecStart=/path/to/pm2/bin/pm2 resurrect

# After (Bun runtime explicit → daemon starts with Bun)
ExecStart=/path/to/bun /path/to/pm2/bin/pm2 resurrect
```

Behavior under Node.js is **unchanged** (verified: `ExecStart` still the bare pm2 binary path).

## Why this matters

Per the [PM2 Bun docs](https://pm2.keymetrics.io/docs/usage/bun-deno/): *"Cluster mode follows the runtime of the PM2 daemon itself"* — to load-balance a Bun app you must run PM2 with Bun (`bunx --bun pm2 start app.ts -i max`). If the init script boots the daemon with node, Bun cluster apps saved via `pm2 save` fail on reboot. This PR makes `pm2 startup` produce a Bun-runtime init script automatically when PM2 is running under Bun.

Also unifies the `isNotRoot()` hint to use the resolved pm2 binary path instead of the hardcoded `'pm2'` string when `--user` is passed.

## Testing

- `pm2 startup` under Node → command hint and unit unchanged (no regression)
- `pm2 startup` under Bun (`bun bin/pm2 startup`) → hint shows `bun <pm2_bin>`, generated systemd unit has `ExecStart=/path/to/bun .../pm2/bin/pm2 resurrect` (verified with a real unit generation + cleanup)
- `npm run test:unit` — only pre-existing flaky test `exp_backoff_restart_delay.mocha.js` fails (fails identically without this change; the project's own runner retries it)

Related issues: #5893, #5777, #5967 (cluster mode with Bun).