### PR TITLE
feat(startup): add systemd-user support for PM2 uninstall/setup commands

### DIFF
--- a/lib/API/Startup.js
+++ b/lib/API/Startup.js
@@ -68,6 +68,10 @@ module.exports = function(CLI) {
     return hash_map[init_systems[i]];
   }
 
+  function isSystemdUserCompatible(actual_platform, target_platform) {
+    return actual_platform === 'systemd' && target_platform === 'systemd-user';
+  }
+
   CLI.prototype.uninstallStartup = function(platform, opts, cb) {
     var commands;
     var that = this;
@@ -79,7 +83,7 @@ module.exports = function(CLI) {
 
     if (!platform)
       platform = actual_platform;
-    else if (actual_platform && actual_platform !== platform) {
+    else if (actual_platform && actual_platform !== platform && !isSystemdUserCompatible(actual_platform, platform)) {
       Common.printOut('-----------------------------------------------------------')
       Common.printOut(' PM2 detected ' + actual_platform + ' but you precised ' + platform)
       Common.printOut(' Please verify that your choice is indeed your init system')
@@ -97,7 +101,7 @@ module.exports = function(CLI) {
       }
     }
 
-    if (process.getuid() != 0) {
+    if (process.getuid() != 0 && !isSystemdUserCompatible(actual_platform, platform)) {
       return isNotRoot('unsetup', platform, opts, cb);
     }
 
@@ -106,6 +110,16 @@ module.exports = function(CLI) {
     }
 
     switch(platform) {
+    case 'systemd-user':
+      var user_home = opts.hp || process.env.HOME || ('/home/' + user);
+      var destination = path.join(user_home, '.config/systemd/user/' + service_name + '.service');
+      commands = [
+        'systemctl --user stop ' + service_name,
+        'systemctl --user disable ' + service_name,
+        'rm ' + destination,
+        'systemctl --user daemon-reload'
+      ];
+      break;
     case 'systemd':
       commands = [
         'systemctl stop ' + service_name,
@@ -205,7 +219,7 @@ module.exports = function(CLI) {
 
     if (!platform)
       platform = actual_platform;
-    else if (actual_platform && actual_platform !== platform) {
+    else if (actual_platform && actual_platform !== platform && !isSystemdUserCompatible(actual_platform, platform)) {
       Common.printOut('-----------------------------------------------------------')
       Common.printOut(' PM2 detected ' + actual_platform + ' but you precised ' + platform)
       Common.printOut(' Please verify that your choice is indeed your init system')
@@ -223,7 +237,7 @@ module.exports = function(CLI) {
       }
     }
 
-    if (process.getuid() != 0) {
+    if (process.getuid() != 0 && !isSystemdUserCompatible(actual_platform, platform)) {
       return isNotRoot('setup', platform, opts, cb);
     }
 
@@ -236,6 +250,21 @@ module.exports = function(CLI) {
     }
 
     switch(platform) {
+    case 'systemd-user':
+      var user_home = opts.hp || process.env.HOME || ('/home/' + user);
+      destination = path.join(user_home, '.config/systemd/user/' + service_name + '.service');
+      if (!fs.existsSync(path.dirname(destination))) {
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+      }
+      if (opts.waitIp)
+        template = getTemplate('systemd-user-online');
+      else
+        template = getTemplate('systemd-user');
+      commands = [
+        'systemctl --user daemon-reload',
+        'systemctl --user enable ' + service_name
+      ];
+      break;
     case 'ubuntu':
     case 'centos':
     case 'arch':

--- a/lib/templates/init-scripts/systemd-user-online.tpl
+++ b/lib/templates/init-scripts/systemd-user-online.tpl
@@ -1,0 +1,21 @@
+[Unit]
+Description=PM2 process manager
+Documentation=https://pm2.keymetrics.io/
+After=network-online.target
+Restart=on-failure
+
+[Service]
+Type=forking
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=PM2_HOME=%HOME_PATH%
+PIDFile=%HOME_PATH%/pm2.pid
+
+ExecStart=%PM2_PATH% resurrect
+ExecReload=%PM2_PATH% reload all
+ExecStop=%PM2_PATH% kill
+
+[Install]
+WantedBy=default.target

--- a/lib/templates/init-scripts/systemd-user-online.tpl
+++ b/lib/templates/init-scripts/systemd-user-online.tpl
@@ -2,16 +2,13 @@
 Description=PM2 process manager
 Documentation=https://pm2.keymetrics.io/
 After=network-online.target
-Restart=on-failure
 
 [Service]
 Type=forking
-LimitNOFILE=infinity
-LimitNPROC=infinity
-LimitCORE=infinity
 Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=PM2_HOME=%HOME_PATH%
 PIDFile=%HOME_PATH%/pm2.pid
+Restart=on-failure
 
 ExecStart=%PM2_PATH% resurrect
 ExecReload=%PM2_PATH% reload all

--- a/lib/templates/init-scripts/systemd-user.tpl
+++ b/lib/templates/init-scripts/systemd-user.tpl
@@ -5,9 +5,6 @@ After=network.target
 
 [Service]
 Type=forking
-LimitNOFILE=infinity
-LimitNPROC=infinity
-LimitCORE=infinity
 Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=PM2_HOME=%HOME_PATH%
 PIDFile=%HOME_PATH%/pm2.pid

--- a/lib/templates/init-scripts/systemd-user.tpl
+++ b/lib/templates/init-scripts/systemd-user.tpl
@@ -1,0 +1,21 @@
+[Unit]
+Description=PM2 process manager
+Documentation=https://pm2.keymetrics.io/
+After=network.target
+
+[Service]
+Type=forking
+LimitNOFILE=infinity
+LimitNPROC=infinity
+LimitCORE=infinity
+Environment=PATH=%NODE_PATH%:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=PM2_HOME=%HOME_PATH%
+PIDFile=%HOME_PATH%/pm2.pid
+Restart=on-failure
+
+ExecStart=%PM2_PATH% resurrect
+ExecReload=%PM2_PATH% reload all
+ExecStop=%PM2_PATH% kill
+
+[Install]
+WantedBy=default.target

--- a/test/programmatic/systemd_user.mocha.js
+++ b/test/programmatic/systemd_user.mocha.js
@@ -1,0 +1,35 @@
+var PM2    = require('../..');
+var should = require('should');
+var path   = require('path');
+var fs     = require('fs');
+
+describe('systemd-user startup testing', function() {
+  var pm2 = new PM2.custom();
+  var user = process.env.USER || process.env.LOGNAME;
+  var targetFile = path.join(process.env.HOME, '.config/systemd/user/pm2-' + user + '.service');
+
+  after(function(done) {
+    pm2.uninstallStartup('systemd-user', {}, function(err) {
+      done();
+    });
+  });
+
+  it('should generate systemd-user startup script without root', function(done) {
+    pm2.startup('systemd-user', {}, function(err, result) {
+      should(err).be.null();
+      should(fs.existsSync(targetFile)).be.true();
+      var content = fs.readFileSync(targetFile, 'utf8');
+      should(content).match(/WantedBy=default\.target/);
+      should(content).not.match(/User=/);
+      done();
+    });
+  });
+
+  it('should uninstall systemd-user startup script', function(done) {
+    pm2.uninstallStartup('systemd-user', {}, function(err, result) {
+      should(err).be.null();
+      should(fs.existsSync(targetFile)).be.false();
+      done();
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -720,7 +720,7 @@ export interface InstallOptions {
 // Types
 
 type ProcessStatus = 'online' | 'stopping' | 'stopped' | 'launching' | 'errored' | 'one-launch-status' | 'waiting_restart';
-type Platform = 'ubuntu' | 'centos' | 'redhat' | 'gentoo' | 'systemd' | 'darwin' | 'amazon';
+type Platform = 'ubuntu' | 'centos' | 'redhat' | 'gentoo' | 'systemd' | 'systemd-user' | 'darwin' | 'amazon';
 
 type ErrCallback = (err: Error) => void;
 type ErrProcCallback = (err: Error, proc: Proc) => void;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2750
| License       | MIT
| Doc PR        | 
### Summary
Add `systemd-user` support for `pm2 startup systemd-user` and `pm2 unstartup systemd-user` commands to generate and manage user-level systemd services via `systemctl --user`.
### Changes
- Add `systemd-user.tpl` and `systemd-user-online.tpl` templates (`WantedBy=default.target`, without `User=` directive).
- Support `systemd-user` platform in `lib/API/Startup.js` allowing non-root execution.
- Auto-create user configuration directory `$HOME/.config/systemd/user/` if not present when generating `systemd-user` units.
- Add TypeScript type definition in `types/index.d.ts`.
- Add programmatic test `test/programmatic/systemd_user.mocha.js`.