### PR TITLE
Fix two ReferenceErrors in error paths

### DIFF
--- a/lib/API/Extra.js
+++ b/lib/API/Extra.js
@@ -700,7 +700,7 @@ module.exports = function(CLI) {
       that.Client.executeRemote('getMonitorData', {}, function(err, list) {
         if (err) {
           console.error('Error retrieving process list: ' + err);
-          that.exitCli(conf.ERROR_EXIT);
+          that.exitCli(cst.ERROR_EXIT);
         }
 
         Monit.refresh(list);

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -160,7 +160,7 @@ function install(name, completer, cb) {
   function next() {
     if(!rc || !scriptOutput) return;
 
-    writeRc(rc + scriptOutput, function(err) {
+    writeRc(completer, rc + scriptOutput, function(err) {
       if(err) return cb(err);
       return cb(null, ' ✓ ' + completer + ' tab-completion installed.');
     });
@@ -180,7 +180,7 @@ function uninstall(name, completer, cb) {
     }
 
     part = markerIn + part.split(markerOut)[0] + markerOut;
-    writeRc(file.replace(part, ''), function(err) {
+    writeRc(completer, file.replace(part, ''), function(err) {
       if(err) return cb(err);
       return cb(null, ' ✓ ' + completer + ' tab-completion uninstalled.');
     });
@@ -196,7 +196,7 @@ function readRc(completer, cb) {
   });
 }
 
-function writeRc(content, cb) {
+function writeRc(completer, content, cb) {
   var file = '.' + process.env.SHELL.match(/\/bin\/(\w+)/)[1] + 'rc',
   filepath = pth.join(process.env.HOME, file);
   fs.lstat(filepath, function (err, stats) {


### PR DESCRIPTION
Both of these sit in code that only runs after something else has already failed, so instead of the message the author wrote, the user gets a stack trace. I could not find an existing issue for either.

Found by running ESLint's `no-undef` over the tree.

---

### 1. `lib/API/Extra.js:703` — `conf` is not defined

```js
that.exitCli(conf.ERROR_EXIT);
```

Every other exit in this file uses `cst.ERROR_EXIT`, and `cst` is what the file requires (`var cst = require('../../constants.js')` on line 8). `conf` is not defined anywhere in it.

Reached when `getMonitorData` fails during `pm2 monit`: the error is logged, and then the process throws `ReferenceError: conf is not defined` instead of exiting with `ERROR_EXIT`.

### 2. `lib/completion.js:203` — `completer` is not defined

`writeRc` looks like a copy of `readRc` with one argument removed, but the body still reads it:

```js
function readRc(completer, cb) {                 // takes completer
  ...
  if (err) return cb(new Error("No " + file + " ... " + completer + " ..."));

function writeRc(content, cb) {                  // does not take completer
  ...
  if (err) return cb(new Error("No " + file + " ... " + completer + " ..."));
```

Reached from `install()` and `uninstall()` when `lstat` on the rc file fails — for example if `$HOME` has no rc file for the current `$SHELL`, or the file is removed between the read and the write.

Both call sites already have `completer` in scope, so threading it through is the smallest change:

```
$ node repro.js
  before: ReferenceError: completer is not defined
  after:  Error: No .zshrc file. You'll have to run instead: pm2 completion >> ~/.zshrc
```

---

Four lines in total. Happy to reshape it — the two functions could also share one stat-and-error helper so the copy cannot drift again, but I kept this minimal on purpose.