### PR TITLE
docs: fix typo wihtout -> without

### DIFF
--- a/lib/God.js
+++ b/lib/God.js
@@ -156,7 +156,7 @@ God.prepare = function prepare (env, cb) {
       return God.executeApp(Utility.clone(_env), function (err, clu) {
         if (err) return next(err);
         God.notify('start', clu, true);
-        // here call next wihtout an array because
+        // here call next without an array because
         // async.times aggregate the result into an array
         return next(null, Utility.clone(clu));
       });


### PR DESCRIPTION
Corrects the misspelling `wihtout` -> `without` in `lib/God.js`.

Documentation only, no behaviour change.