### PR TITLE
fix: forward string env vars to cluster.fork() so NODE_EXTRA_CA_CERTS etc. actually apply

### DIFF
--- a/lib/God/ClusterMode.js
+++ b/lib/God/ClusterMode.js
@@ -59,6 +59,24 @@ module.exports = function ClusterMode(God) {
     // land in pm2.log (#3675 #4719 #4872 #4916 #4953 #5633)
     var stds = StdioLogger.stdsFromEnv(env_copy);
 
+    // node.js cluster clients can not receive deep-level objects or arrays in the forked process, e.g.:
+    // { "args": ["foo", "bar"], "env": { "foo1": "bar1" }} will be parsed to
+    // { "args": "foo, bar", "env": "[object Object]"}
+    // So we passing a stringified JSON here.
+    //
+    // Some Node.js env vars (NODE_EXTRA_CA_CERTS, NODE_OPTIONS, ...) are only read once
+    // at process bootstrap, before pm2_env gets parsed and applied to process.env - by
+    // then it's too late for them to take effect. Forward the string-typed entries of
+    // env_copy as real env vars too, so cluster.fork() exposes them at boot time exactly
+    // like fork mode already does. Non-string values are skipped on purpose to avoid the
+    // "[object Object]" leak this same function already guards against above.
+    var forkEnv = {pm2_env: JSON.stringify(env_copy), windowsHide: true};
+    Object.keys(env_copy).forEach(function(key) {
+      if (typeof env_copy[key] === 'string') {
+        forkEnv[key] = env_copy[key];
+      }
+    });
+
     Utility.startLogging(stds, function(err) {
       if (err) {
         God.logAndGenerateError(err);
@@ -66,11 +84,7 @@ module.exports = function ClusterMode(God) {
       }
 
       try {
-        // node.js cluster clients can not receive deep-level objects or arrays in the forked process, e.g.:
-        // { "args": ["foo", "bar"], "env": { "foo1": "bar1" }} will be parsed to
-        // { "args": "foo, bar", "env": "[object Object]"}
-        // So we passing a stringified JSON here.
-        clu = cluster.fork({pm2_env: JSON.stringify(env_copy), windowsHide: true});
+        clu = cluster.fork(forkEnv);
       } catch(e) {
         God.logAndGenerateError(e);
         StdioLogger.close(stds);

--- a/test/fixtures/node-extra-ca-certs/client.js
+++ b/test/fixtures/node-extra-ca-certs/client.js
@@ -1,0 +1,17 @@
+// Connects to the private-CA-signed test server started by
+// https-server.js. Succeeds only if NODE_EXTRA_CA_CERTS was actually
+// applied before Node's TLS bootstrap - having it set in process.env
+// afterwards is not enough (see issue #5919).
+var https = require('https')
+var fs = require('fs')
+
+var resultFile = process.env.TEST_RESULT_FILE
+var port = process.env.TEST_SERVER_PORT
+
+https.get('https://127.0.0.1:' + port + '/', function (res) {
+  fs.writeFileSync(resultFile, JSON.stringify({ok: true, statusCode: res.statusCode}))
+  process.exit(0)
+}).on('error', function (err) {
+  fs.writeFileSync(resultFile, JSON.stringify({ok: false, code: err.code}))
+  process.exit(1)
+})

--- a/test/fixtures/node-extra-ca-certs/https-server.js
+++ b/test/fixtures/node-extra-ca-certs/https-server.js
@@ -1,0 +1,16 @@
+// Minimal HTTPS server signed by a private CA, started outside of PM2.
+// Used by issue_5919_node_extra_ca_certs.mocha.js to check whether
+// NODE_EXTRA_CA_CERTS is actually honored by TLS in cluster mode workers,
+// not just present in process.env.
+var https = require('https')
+var fs = require('fs')
+
+var options = {
+  key: fs.readFileSync(process.env.TEST_SERVER_KEY),
+  cert: fs.readFileSync(process.env.TEST_SERVER_CERT)
+}
+
+https.createServer(options, function (req, res) {
+  res.writeHead(200)
+  res.end('ok')
+}).listen(process.env.TEST_SERVER_PORT, '127.0.0.1')

--- a/test/programmatic/issue_5919_node_extra_ca_certs.mocha.js
+++ b/test/programmatic/issue_5919_node_extra_ca_certs.mocha.js
@@ -1,0 +1,92 @@
+process.chdir(__dirname)
+
+var fs = require('fs')
+var os = require('os')
+var path = require('path')
+var execSync = require('child_process').execSync
+var https = require('https')
+var PM2 = require('../..')
+var should = require('should')
+
+var FIXTURES = path.join(__dirname, '..', 'fixtures', 'node-extra-ca-certs')
+var TMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'pm2-issue-5919-'))
+var CA_KEY = path.join(TMP_DIR, 'ca-key.pem')
+var CA_CERT = path.join(TMP_DIR, 'ca-cert.pem')
+var SERVER_KEY = path.join(TMP_DIR, 'server-key.pem')
+var SERVER_CERT = path.join(TMP_DIR, 'server-cert.pem')
+var SAN_CONF = path.join(TMP_DIR, 'san.cnf')
+var RESULT_FILE = path.join(TMP_DIR, 'result.json')
+var PORT = 18443
+
+describe('Issue #5919 - NODE_EXTRA_CA_CERTS not applied to cluster mode workers', function () {
+  this.timeout(30000)
+
+  var server
+
+  before(function () {
+    // Self-signed private CA + a server cert issued by it, generated fresh
+    // for this test run - nothing here talks to the network.
+    execSync('openssl req -x509 -newkey rsa:2048 -nodes -keyout ' + CA_KEY +
+      ' -out ' + CA_CERT + ' -days 1 -subj "/CN=pm2-test-ca"')
+    execSync('openssl req -newkey rsa:2048 -nodes -keyout ' + SERVER_KEY +
+      ' -out ' + path.join(TMP_DIR, 'server-csr.pem') + ' -subj "/CN=localhost"')
+    fs.writeFileSync(SAN_CONF, 'subjectAltName=DNS:localhost,IP:127.0.0.1')
+    execSync('openssl x509 -req -in ' + path.join(TMP_DIR, 'server-csr.pem') +
+      ' -CA ' + CA_CERT + ' -CAkey ' + CA_KEY + ' -CAcreateserial -out ' +
+      SERVER_CERT + ' -days 1 -extfile ' + SAN_CONF)
+
+    server = require('child_process').fork(path.join(FIXTURES, 'https-server.js'), {
+      env: {
+        TEST_SERVER_KEY: SERVER_KEY,
+        TEST_SERVER_CERT: SERVER_CERT,
+        TEST_SERVER_PORT: PORT
+      },
+      stdio: 'ignore'
+    })
+
+    // Give the server a moment to bind before PM2 apps try to reach it.
+    var deadline = Date.now() + 5000
+    while (Date.now() < deadline) {
+      try {
+        execSync('curl -sk -o /dev/null https://127.0.0.1:' + PORT + '/')
+        break
+      } catch (e) {}
+    }
+  })
+
+  after(function (done) {
+    if (server) server.kill()
+    try { fs.rmSync(TMP_DIR, {recursive: true, force: true}) } catch (e) {}
+    PM2.kill(done)
+  })
+
+  beforeEach(function (done) {
+    try { fs.unlinkSync(RESULT_FILE) } catch (e) {}
+    PM2.delete('all', function () { done() })
+  })
+
+  it('should apply NODE_EXTRA_CA_CERTS to a cluster mode worker before its first TLS connection', function (done) {
+    PM2.start({
+      script: path.join(FIXTURES, 'client.js'),
+      name: 'test-cluster-ca-certs',
+      exec_mode: 'cluster',
+      instances: 1,
+      autorestart: false,
+      force: true,
+      env: {
+        NODE_EXTRA_CA_CERTS: CA_CERT,
+        TEST_SERVER_PORT: String(PORT),
+        TEST_RESULT_FILE: RESULT_FILE
+      }
+    }, function (err) {
+      should(err).be.null()
+
+      setTimeout(function () {
+        var data = JSON.parse(fs.readFileSync(RESULT_FILE, 'utf8'))
+        data.ok.should.eql(true,
+          'cluster worker could not reach the CA-signed server: ' + JSON.stringify(data))
+        done()
+      }, 2000)
+    })
+  })
+})


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #5919
| License       | MIT
| Doc PR        | n/a

Fixes #5919.

`God.nodeApp` calls `cluster.fork({pm2_env: JSON.stringify(env_copy), windowsHide: true})`, so the only real env vars a cluster worker gets at boot are `pm2_env` and `windowsHide`. Everything the app itself set - `NODE_EXTRA_CA_CERTS` being the one people keep hitting - only shows up later, once pm2 parses `pm2_env` and assigns it onto `process.env`. That's after Node has already done its one-time TLS bootstrap read, so it's too late for anything Node only reads at startup.

Fork mode doesn't have this problem since it passes the real env through directly, which is exactly why "works in fork mode, breaks in cluster mode" is the recurring symptom in #5919.

#3117 proposed fixing this for `NODE_EXTRA_CA_CERTS` specifically back in 2017 but never got merged. This does the same thing but generally: every string-typed key in `env_copy` gets forwarded as a real env var to `cluster.fork()`, not just that one. Non-string values are deliberately skipped, since that's what the `[object Object]` leak in #6073 was about and I didn't want to reopen that.

To confirm this was actually the bug and not something else, I set up a private CA + a small HTTPS server locally and pointed `NODE_EXTRA_CA_CERTS` at the CA cert. Cluster mode failed with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` - and `process.env.NODE_EXTRA_CA_CERTS` was correct inside the worker the whole time, which is what pointed me at the timing issue instead of a missing-value issue.

Added `test/programmatic/issue_5919_node_extra_ca_certs.mocha.js` doing the same thing (private CA generated on the fly, real HTTPS request from inside a cluster worker). It fails on master and passes with this patch. Ran it alongside `issue_6073_object_env`, `cluster.mocha.js`, `filter_env.mocha.js` and `env_switching.js` and all still pass.
